### PR TITLE
Add ReadOnly Connector

### DIFF
--- a/packages/use-contractkit/src/connectors/connectors-by-name.ts
+++ b/packages/use-contractkit/src/connectors/connectors-by-name.ts
@@ -1,4 +1,3 @@
-import { ReadOnlyConnector } from '.';
 import { WalletTypes } from '../constants';
 import { Connector, Network } from '../types';
 import {
@@ -9,6 +8,7 @@ import {
   PrivateKeyConnector,
   UnauthenticatedConnector,
   WalletConnectConnector,
+  ReadOnlyConnector,
 } from './connectors';
 
 /**

--- a/packages/use-contractkit/src/connectors/connectors-by-name.ts
+++ b/packages/use-contractkit/src/connectors/connectors-by-name.ts
@@ -1,3 +1,4 @@
+import { ReadOnlyConnector } from '.';
 import { WalletTypes } from '../constants';
 import { Connector, Network } from '../types';
 import {
@@ -28,4 +29,5 @@ export const CONNECTOR_TYPES: {
   [WalletTypes.CeloDance]: WalletConnectConnector,
   [WalletTypes.CeloTerminal]: WalletConnectConnector,
   [WalletTypes.CeloWallet]: WalletConnectConnector,
+  [WalletTypes.ReadOnly]: ReadOnlyConnector,
 };

--- a/packages/use-contractkit/src/connectors/connectors.ts
+++ b/packages/use-contractkit/src/connectors/connectors.ts
@@ -40,6 +40,7 @@ export class UnauthenticatedConnector implements Connector {
   }
 }
 
+/* eslint-disable */
 // TODO: Move this to wallet-base maybe
 class ReadOnlyWallet implements Wallet {
   constructor(public readonly account: string) {}
@@ -72,6 +73,7 @@ class ReadOnlyWallet implements Wallet {
     throw Error('Not implemented');
   }
 }
+/* eslint-enable */
 
 export class ReadOnlyConnector implements Connector {
   public initialised = true;
@@ -87,6 +89,7 @@ export class ReadOnlyConnector implements Connector {
       JSON.stringify([account])
     );
     localStorage.setItem(localStorageKeys.lastUsedNetwork, n.name);
+    // eslint-disable-next-line
     // @ts-ignore
     this.kit = newKit(n.rpcUrl, new ReadOnlyWallet(account));
     this.kit.defaultAccount = account;

--- a/packages/use-contractkit/src/connectors/connectors.ts
+++ b/packages/use-contractkit/src/connectors/connectors.ts
@@ -40,7 +40,7 @@ export class UnauthenticatedConnector implements Connector {
   }
 }
 
-/* eslint-disable */
+/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-empty-function */
 // TODO: Move this to wallet-base maybe
 class ReadOnlyWallet implements Wallet {
   constructor(public readonly account: string) {}

--- a/packages/use-contractkit/src/connectors/connectors.ts
+++ b/packages/use-contractkit/src/connectors/connectors.ts
@@ -1,4 +1,5 @@
 import { ContractKit, newKit, newKitFromWeb3 } from '@celo/contractkit';
+import { Wallet } from '@celo/wallet-base';
 import { LocalWallet } from '@celo/wallet-local';
 import {
   WalletConnectWallet,
@@ -33,6 +34,67 @@ export class UnauthenticatedConnector implements Connector {
     return this;
   }
 
+  close(): void {
+    clearPreviousConfig();
+    return;
+  }
+}
+
+// TODO: Move this to wallet-base maybe
+class ReadOnlyWallet implements Wallet {
+  constructor(public readonly account: string) {}
+  addAccount() {}
+  getAccounts() {
+    return [this.account];
+  }
+  removeAccount() {}
+  hasAccount(address?: string | undefined) {
+    return !!address && address === this.account;
+  }
+  // @ts-ignore
+  signTransaction() {
+    throw Error('Not implemented');
+  }
+  // @ts-ignore
+  signTypedData() {
+    throw Error('Not implemented');
+  }
+  // @ts-ignore
+  signPersonalMessage() {
+    throw Error('Not implemented');
+  }
+  // @ts-ignore
+  decrypt() {
+    throw Error('Not implemented');
+  }
+  // @ts-ignore
+  computeSharedSecret() {
+    throw Error('Not implemented');
+  }
+}
+
+export class ReadOnlyConnector implements Connector {
+  public initialised = true;
+  public type = WalletTypes.ReadOnly;
+  public kit: ContractKit;
+  constructor(n: Network, public readonly account: string) {
+    localStorage.setItem(
+      localStorageKeys.lastUsedWalletType,
+      WalletTypes.ReadOnly
+    );
+    localStorage.setItem(
+      localStorageKeys.lastUsedWalletArguments,
+      JSON.stringify([account])
+    );
+    localStorage.setItem(localStorageKeys.lastUsedNetwork, n.name);
+    // @ts-ignore
+    this.kit = newKit(n.rpcUrl, new ReadOnlyWallet(account));
+    this.kit.defaultAccount = account;
+  }
+  initialise(): this {
+    this.initialised = true;
+    return this;
+  }
   close(): void {
     clearPreviousConfig();
     return;

--- a/packages/use-contractkit/src/constants.tsx
+++ b/packages/use-contractkit/src/constants.tsx
@@ -30,6 +30,7 @@ export enum SupportedProviders {
   MetaMask = 'MetaMask',
   PrivateKey = 'Private key',
   Valora = 'Valora',
+  ReadOnly = 'Readonly',
   WalletConnect = 'WalletConnect',
 }
 
@@ -131,6 +132,14 @@ export const PROVIDERS: {
     showInList: () => process.env.NODE_ENV !== 'production',
     listPriority: () => 1,
   },
+  [SupportedProviders.ReadOnly]: {
+    name: 'Readonly',
+    description: 'Enter an address to "pretend" to be it',
+    icon: PRIVATE_KEY,
+    canConnect: () => true,
+    showInList: () => true,
+    listPriority: () => 1,
+  },
   [SupportedProviders.CeloDance]: {
     name: 'CeloDance',
     description: 'Send, vote, and earn rewards within one wallet',
@@ -195,6 +204,7 @@ export enum WalletTypes {
   Ledger = 'Ledger',
   Injected = 'Injected',
   PrivateKey = 'PrivateKey',
+  ReadOnly = 'ReadOnly',
   Unauthenticated = 'Unauthenticated',
 }
 

--- a/packages/use-contractkit/src/constants.tsx
+++ b/packages/use-contractkit/src/constants.tsx
@@ -132,14 +132,6 @@ export const PROVIDERS: {
     showInList: () => process.env.NODE_ENV !== 'production',
     listPriority: () => 1,
   },
-  [SupportedProviders.ReadOnly]: {
-    name: 'Readonly',
-    description: 'Enter an address to "pretend" to be it',
-    icon: PRIVATE_KEY,
-    canConnect: () => true,
-    showInList: () => true,
-    listPriority: () => 1,
-  },
   [SupportedProviders.CeloDance]: {
     name: 'CeloDance',
     description: 'Send, vote, and earn rewards within one wallet',
@@ -148,6 +140,14 @@ export const PROVIDERS: {
     showInList: () => true,
     listPriority: () => 1,
     installURL: 'https://celo.dance/',
+  },
+  [SupportedProviders.ReadOnly]: {
+    name: 'Readonly',
+    description: 'Use an address without sending transactions',
+    icon: PRIVATE_KEY,
+    canConnect: () => true,
+    showInList: () => true,
+    listPriority: () => 1,
   },
 };
 

--- a/packages/use-contractkit/src/modals/connect.tsx
+++ b/packages/use-contractkit/src/modals/connect.tsx
@@ -59,6 +59,7 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
           typeof window !== 'undefined' &&
           provider.showInList() &&
           Object.keys(screens).find((screen) => screen === provider.name) &&
+          // eslint-disable-next-line
           // @ts-ignore cant deduce that the keys are from the SupportedProviders enum
           !denylist.includes(providerKey)
       ),

--- a/packages/use-contractkit/src/modals/connect.tsx
+++ b/packages/use-contractkit/src/modals/connect.tsx
@@ -21,12 +21,14 @@ export interface ConnectModalProps {
   };
   RenderProvider?: React.FC<{ provider: Provider; onClick: () => void }>;
   reactModalProps?: Partial<ReactModal.Props>;
+  denylist?: SupportedProviders[];
 }
 
 export const ConnectModal: React.FC<ConnectModalProps> = ({
   reactModalProps,
   RenderProvider = ProviderSelect,
   screens = defaultScreens,
+  denylist = [SupportedProviders.ReadOnly],
 }: ConnectModalProps) => {
   const { connectionCallback } = useContractKitInternal();
   const [adding, setAdding] = useState<SupportedProviders | null>(null);
@@ -53,10 +55,12 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
   const providers = useMemo<[providerKey: string, provider: Provider][]>(
     () =>
       Object.entries(PROVIDERS).filter(
-        ([, provider]) =>
+        ([providerKey, provider]) =>
           typeof window !== 'undefined' &&
           provider.showInList() &&
-          Object.keys(screens).find((screen) => screen === provider.name)
+          Object.keys(screens).find((screen) => screen === provider.name) &&
+          // @ts-ignore cant deduce that the keys are from the SupportedProviders enum
+          !denylist.includes(providerKey)
       ),
     [screens]
   );

--- a/packages/use-contractkit/src/screens/index.ts
+++ b/packages/use-contractkit/src/screens/index.ts
@@ -8,6 +8,7 @@ import { CeloExtensionWallet } from './cew';
 import { Ledger } from './ledger';
 import { MetaMaskWallet } from './metamask';
 import { PrivateKey } from './private-key';
+import { ReadOnly } from './readonly';
 import { Valora } from './valora';
 import { WalletConnect } from './wallet-connect';
 
@@ -24,6 +25,7 @@ export const defaultScreens: {
   [SupportedProviders.CeloExtensionWallet]: CeloExtensionWallet,
   [SupportedProviders.Injected]: MetaMaskWallet,
   [SupportedProviders.PrivateKey]: PrivateKey,
+  [SupportedProviders.ReadOnly]: ReadOnly,
 };
 
 export type ConnectorProps = {

--- a/packages/use-contractkit/src/screens/readonly.tsx
+++ b/packages/use-contractkit/src/screens/readonly.tsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+
+import { ReadOnlyConnector } from '../connectors';
+import { useContractKit } from '../use-contractkit';
+import { ConnectorProps } from '.';
+import { useContractKitInternal } from '..';
+
+export const ReadOnly: React.FC<ConnectorProps> = ({
+  onSubmit,
+}: ConnectorProps) => {
+  const [value, setValue] = useState('');
+  const { network } = useContractKit();
+  const { initConnector } = useContractKitInternal();
+
+  const handleSubmit = async () => {
+    if (!value) {
+      return;
+    }
+
+    const connector = new ReadOnlyConnector(network, value);
+    await initConnector(connector);
+    void onSubmit(connector);
+  };
+
+  return (
+    <div className="tw-p-2">
+      <div className="tw-flex tw-flex-col">
+        <div className="tw-text-xl tw-text-gray-800 dark:tw-text-gray-200">
+          Enter the address you would like to act as
+        </div>
+        <div className="tw-flex tw-flex-col">
+          <input
+            className="tw-border tw-border-gray-300 dark:tw-border-gray-700 dark:tw-bg-gray-700 dark:tw-text-gray-300 tw-rounded-md tw-mt-3 tw-px-3 tw-py-2"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+          />
+          <button
+            className="tw-mt-3 tw-px-4 tw-py-2 tw-border tw-border-transparent tw-rounded-md tw-shadow-sm tw-text-base tw-font-medium tw-text-white tw-bg-gradient-to-r tw-from-purple-600 tw-to-indigo-600 hover:tw-from-purple-700 hover:tw-to-indigo-700"
+            onClick={handleSubmit}
+          >
+            Submit
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
This PR adds a ReadOnly Connector, which accomplishes similar things to https://github.com/CodinMaster/impersonator

I.e. it allows users to enter any address and use the dapp as such. I also introduced a denylist feature that excludes this connector by default (since of course any mutative action does not actually work)