### PR TITLE
Explicitly add the chain Id to the JSONRPCPROVIDER

### DIFF
--- a/packages/use-contractkit/src/ethers.ts
+++ b/packages/use-contractkit/src/ethers.ts
@@ -8,9 +8,10 @@ import { useIsMounted } from './utils/useIsMounted';
 export const useProvider = (): Web3Provider => {
   const { kit, network } = useContractKit();
   const provider = kit.web3.currentProvider as unknown as ExternalProvider;
+  const { chainId, name } = network;
   return useMemo(() => {
-    return new Web3Provider(provider, {chainId: network.chainId, name: network.name});
-  }, [provider]);
+    return new Web3Provider(provider, { chainId, name });
+  }, [provider, chainId, name]);
 };
 
 export const useProviderOrSigner = (): Web3Provider | JsonRpcSigner => {
@@ -24,17 +25,22 @@ export const useProviderOrSigner = (): Web3Provider | JsonRpcSigner => {
 };
 
 export const useGetConnectedSigner = (): (() => Promise<JsonRpcSigner>) => {
-  const { kit, getConnectedKit } = useContractKit();
+  const { kit, getConnectedKit, network } = useContractKit();
   const signer = useProviderOrSigner();
+  const { chainId, name } = network;
+
   return useCallback(async () => {
     if (kit.defaultAccount) {
       return signer as JsonRpcSigner;
     }
+
     const nextKit = await getConnectedKit();
     const nextProvider = nextKit.web3
       .currentProvider as unknown as ExternalProvider;
-    return new Web3Provider(nextProvider).getSigner(nextKit.defaultAccount);
-  }, [kit.defaultAccount, getConnectedKit, signer]);
+    return new Web3Provider(nextProvider, { chainId, name }).getSigner(
+      nextKit.defaultAccount
+    );
+  }, [kit.defaultAccount, getConnectedKit, signer, chainId, name]);
 };
 
 export const useLazyConnectedSigner = (): {

--- a/packages/use-contractkit/src/ethers.ts
+++ b/packages/use-contractkit/src/ethers.ts
@@ -6,10 +6,10 @@ import { useContractKit } from './use-contractkit';
 import { useIsMounted } from './utils/useIsMounted';
 
 export const useProvider = (): Web3Provider => {
-  const { kit } = useContractKit();
+  const { kit, network } = useContractKit();
   const provider = kit.web3.currentProvider as unknown as ExternalProvider;
   return useMemo(() => {
-    return new Web3Provider(provider);
+    return new Web3Provider(provider, {chainId: network.chainId, name: network.name});
   }, [provider]);
 };
 


### PR DESCRIPTION
Without this ether js JsonRPC provider seems to call a detectNetwork Function every event loop which makes a call the node like  {method: eth_ChainID, params: [], id: randomNumber()}