### PR TITLE
Fix promise typing for updateNetwork

### DIFF
--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -270,12 +270,12 @@ export default function Home(): React.ReactElement {
               <select
                 className="border border-gray-300 rounded px-4 py-2"
                 value={network.name}
-                onChange={(e) => {
+                onChange={async (e) => {
                   const newNetwork = networks.find(
                     (n) => n.name === e.target.value
                   );
                   if (newNetwork) {
-                    updateNetwork(newNetwork);
+                    await updateNetwork(newNetwork);
                   }
                 }}
               >

--- a/packages/use-contractkit/src/use-contract-kit-methods.ts
+++ b/packages/use-contractkit/src/use-contract-kit-methods.ts
@@ -1,6 +1,5 @@
 import { ContractKit } from '@celo/contractkit';
 import { useCallback } from 'react';
-
 import { CONNECTOR_TYPES } from './connectors';
 import {
   localStorageKeys,
@@ -69,7 +68,7 @@ export function useContractKitMethods(
   const updateNetwork = useCallback(
     async (newNetwork: Network) => {
       if (STATIC_NETWORK_WALLETS.includes(connector.type)) {
-        return console.error(
+        throw new Error(
           "The connected wallet's network must be changed from the wallet."
         );
       }

--- a/packages/use-contractkit/src/use-contractkit.tsx
+++ b/packages/use-contractkit/src/use-contractkit.tsx
@@ -1,5 +1,4 @@
 import { ContractKit } from '@celo/contractkit';
-
 import { WalletTypes } from './constants';
 import { useContractKitContext } from './contract-kit-provider';
 import { Connector, Dapp, Network } from './types';
@@ -18,7 +17,7 @@ export interface UseContractKit {
   connect: () => Promise<Connector>;
   destroy: () => Promise<void>;
   network: Network;
-  updateNetwork: (network: Network) => void;
+  updateNetwork: (network: Network) => Promise<void>;
 
   /**
    * Helper function for handling any interaction with a Celo wallet. Perform action will


### PR DESCRIPTION
Have updateNetwork correctly typed to return a Promise (as it's async) and have it throw on failure so UIs can observe and react.

**THIS IS A POSSIBLY SMALL BREAKING CHANGE**
Users of updateNetwork that also have a lint rule to forbid hanging promises will need to await or catch