### PR TITLE
change kit on network switch and add feeCurrency to the provider

### DIFF
--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -39,7 +39,6 @@ export default function Home(): React.ReactElement {
     destroy,
     performActions,
     walletType,
-    feeCurrency,
   } = useContractKit();
   const [summary, setSummary] = useState(defaultSummary);
   const [sending, setSending] = useState(false);

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -39,6 +39,7 @@ export default function Home(): React.ReactElement {
     destroy,
     performActions,
     walletType,
+    feeCurrency,
   } = useContractKit();
   const [summary, setSummary] = useState(defaultSummary);
   const [sending, setSending] = useState(false);

--- a/packages/use-contractkit/src/connectors/connectors.ts
+++ b/packages/use-contractkit/src/connectors/connectors.ts
@@ -314,7 +314,7 @@ export class CeloExtensionWalletConnector implements Connector {
   }
   async updateFeeCurrency(feeContract: CeloTokenContract): Promise<void> {
     this.feeCurrency = feeContract;
-    await this.kit.setFeeCurrency(feeContract);
+    await this.kit.setFeeCurrency(this.feeCurrency);
   }
 
   onNetworkChange(callback: (chainId: number) => void): void {

--- a/packages/use-contractkit/src/connectors/connectors.ts
+++ b/packages/use-contractkit/src/connectors/connectors.ts
@@ -1,4 +1,10 @@
-import { ContractKit, newKit, newKitFromWeb3 } from '@celo/contractkit';
+import {
+  CeloContract,
+  CeloTokenContract,
+  ContractKit,
+  newKit,
+  newKitFromWeb3,
+} from '@celo/contractkit';
 import { LocalWallet } from '@celo/wallet-local';
 import {
   WalletConnectWallet,
@@ -27,7 +33,7 @@ export class UnauthenticatedConnector implements Connector {
   public type = WalletTypes.Unauthenticated;
   public kit: ContractKit;
   public account: string | null = null;
-
+  public feeCurrency: CeloTokenContract = CeloContract.GoldToken;
   constructor(n: Network) {
     this.kit = newKit(n.rpcUrl);
   }
@@ -35,6 +41,11 @@ export class UnauthenticatedConnector implements Connector {
   initialise(): this {
     this.initialised = true;
     return this;
+  }
+
+  async updateFeeCurrency(feeContract: CeloTokenContract): Promise<void> {
+    this.feeCurrency = feeContract;
+    await this.kit.setFeeCurrency(feeContract);
   }
 
   close(): void {
@@ -49,7 +60,11 @@ export class PrivateKeyConnector implements Connector {
   public kit: ContractKit;
   public account: string | null = null;
 
-  constructor(n: Network, privateKey: string) {
+  constructor(
+    n: Network,
+    privateKey: string,
+    public feeCurrency: CeloTokenContract
+  ) {
     localStorage.setItem(
       localStorageKeys.lastUsedWalletType,
       WalletTypes.PrivateKey
@@ -68,9 +83,16 @@ export class PrivateKeyConnector implements Connector {
     this.account = this.kit.defaultAccount ?? null;
   }
 
-  initialise(): this {
+  async initialise(): Promise<this> {
+    await this.updateFeeCurrency(this.feeCurrency);
     this.initialised = true;
     return this;
+  }
+
+  async updateFeeCurrency(feeContract: CeloTokenContract): Promise<void> {
+    this.feeCurrency = feeContract;
+    const res = await this.kit.setFeeCurrency(feeContract);
+    console.log(res, 'console');
   }
 
   close(): void {
@@ -85,7 +107,11 @@ export class LedgerConnector implements Connector {
   public kit: ContractKit;
   public account: string | null = null;
 
-  constructor(private network: Network, private index: number) {
+  constructor(
+    private network: Network,
+    private index: number,
+    public feeCurrency: CeloTokenContract
+  ) {
     localStorage.setItem(
       localStorageKeys.lastUsedWalletType,
       WalletTypes.Ledger
@@ -95,8 +121,8 @@ export class LedgerConnector implements Connector {
       JSON.stringify([index])
     );
     localStorage.setItem(localStorageKeys.lastUsedNetwork, network.name);
-
     this.kit = newKit(network.rpcUrl);
+    console.log(this.kit, 'kit');
   }
 
   async initialise(): Promise<this> {
@@ -112,7 +138,12 @@ export class LedgerConnector implements Connector {
 
     this.initialised = true;
     this.account = this.kit.defaultAccount ?? null;
+    await this.updateFeeCurrency(this.feeCurrency);
     return this;
+  }
+  async updateFeeCurrency(feeContract: CeloTokenContract): Promise<void> {
+    this.feeCurrency = feeContract;
+    await this.kit.setFeeCurrency(feeContract);
   }
 
   close(): void {
@@ -139,6 +170,7 @@ export class InjectedConnector implements Connector {
 
   constructor(
     network: Network,
+    public feeCurrency: CeloTokenContract,
     defaultType: WalletTypes = WalletTypes.Injected
   ) {
     this.type = defaultType;
@@ -148,7 +180,6 @@ export class InjectedConnector implements Connector {
       JSON.stringify([])
     );
     localStorage.setItem(localStorageKeys.lastUsedNetwork, network.name);
-
     this.kit = newKit(network.rpcUrl);
   }
 
@@ -188,9 +219,20 @@ export class InjectedConnector implements Connector {
     const [defaultAccount] = await this.kit.web3.eth.getAccounts();
     this.kit.defaultAccount = defaultAccount;
     this.account = defaultAccount ?? null;
+    await this.updateFeeCurrency(this.feeCurrency);
     this.initialised = true;
 
     return this;
+  }
+
+  async updateFeeCurrency(feeContract: CeloTokenContract): Promise<void> {
+    this.feeCurrency = feeContract;
+    await this.kit.setFeeCurrency(feeContract);
+  }
+
+  async updateKitWithNetwork(network: Network): Promise<void> {
+    localStorage.setItem(localStorageKeys.lastUsedNetwork, network.name);
+    await this.initialise();
   }
 
   onNetworkChange(callback: (chainId: number) => void): void {
@@ -210,8 +252,8 @@ export class InjectedConnector implements Connector {
 }
 
 export class MetaMaskConnector extends InjectedConnector {
-  constructor(network: Network) {
-    super(network, WalletTypes.MetaMask);
+  constructor(network: Network, feeCurrency: CeloTokenContract) {
+    super(network, feeCurrency, WalletTypes.MetaMask);
   }
 }
 
@@ -222,7 +264,7 @@ export class CeloExtensionWalletConnector implements Connector {
   public account: string | null = null;
   private onNetworkChangeCallback?: (chainId: number) => void;
 
-  constructor(network: Network) {
+  constructor(network: Network, public feeCurrency: CeloTokenContract) {
     localStorage.setItem(
       localStorageKeys.lastUsedWalletType,
       WalletTypes.CeloExtensionWallet
@@ -232,7 +274,6 @@ export class CeloExtensionWalletConnector implements Connector {
       JSON.stringify([])
     );
     localStorage.setItem(localStorageKeys.lastUsedNetwork, network.name);
-
     this.kit = newKit(network.rpcUrl);
   }
 
@@ -265,9 +306,15 @@ export class CeloExtensionWalletConnector implements Connector {
     const [defaultAccount] = await this.kit.web3.eth.getAccounts();
     this.kit.defaultAccount = defaultAccount;
     this.account = defaultAccount ?? null;
+
+    await this.updateFeeCurrency(this.feeCurrency);
     this.initialised = true;
 
     return this;
+  }
+  async updateFeeCurrency(feeContract: CeloTokenContract): Promise<void> {
+    this.feeCurrency = feeContract;
+    await this.kit.setFeeCurrency(feeContract);
   }
 
   onNetworkChange(callback: (chainId: number) => void): void {
@@ -291,6 +338,7 @@ export class WalletConnectConnector implements Connector {
 
   constructor(
     readonly network: Network,
+    public feeCurrency: CeloTokenContract,
     options: WalletConnectWalletOptions | WalletConnectWalletOptionsV1,
     readonly autoOpen = false,
     readonly getDeeplinkUrl?: (uri: string) => string,
@@ -345,6 +393,8 @@ export class WalletConnectConnector implements Connector {
     const defaultAccount = await this.fetchWalletAddressForAccount(address);
     this.kit.defaultAccount = defaultAccount;
     this.account = defaultAccount ?? null;
+
+    await this.updateFeeCurrency(this.feeCurrency);
     this.initialised = true;
 
     return this;
@@ -357,6 +407,11 @@ export class WalletConnectConnector implements Connector {
     const accounts = await this.kit.contracts.getAccounts();
     const walletAddress = await accounts.getWalletAddress(address);
     return new BigNumber(walletAddress).isZero() ? address : walletAddress;
+  }
+
+  async updateFeeCurrency(feeContract: CeloTokenContract): Promise<void> {
+    this.feeCurrency = feeContract;
+    await this.kit.setFeeCurrency(feeContract);
   }
 
   close(): Promise<void> {

--- a/packages/use-contractkit/src/connectors/useMetaMaskConnector.ts
+++ b/packages/use-contractkit/src/connectors/useMetaMaskConnector.ts
@@ -9,6 +9,7 @@ export function useMetaMaskConnector(
 ): UseMetaMaskConnector {
   const {
     network,
+    feeCurrency,
     initConnector,
     initError: error,
     dapp,
@@ -17,7 +18,7 @@ export function useMetaMaskConnector(
   useEffect(() => {
     let stale;
     void (async () => {
-      const connector = new MetaMaskConnector(network);
+      const connector = new MetaMaskConnector(network, feeCurrency);
       try {
         await initConnector(connector);
         if (!stale) {

--- a/packages/use-contractkit/src/connectors/useMetaMaskConnector.ts
+++ b/packages/use-contractkit/src/connectors/useMetaMaskConnector.ts
@@ -32,7 +32,7 @@ export function useMetaMaskConnector(
     return () => {
       stale = true;
     };
-  }, [initConnector, network, onSubmit]);
+  }, [initConnector, network, onSubmit, feeCurrency]);
 
   return { error, dapp, network };
 }

--- a/packages/use-contractkit/src/connectors/useWalletConnectConnector.ts
+++ b/packages/use-contractkit/src/connectors/useWalletConnectConnector.ts
@@ -13,7 +13,8 @@ export function useWalletConnectConnector(
   getDeeplinkUrl?: (uri: string) => string,
   walletId?: WalletIds
 ): string {
-  const { network, dapp, destroy, initConnector } = useContractKitInternal();
+  const { network, feeCurrency, dapp, destroy, initConnector } =
+    useContractKitInternal();
   const [uri, setUri] = useState('');
   const version = useWalletVersion(walletId);
 
@@ -31,6 +32,7 @@ export function useWalletConnectConnector(
       const relayProvider = 'wss://relay.walletconnect.org';
       const connector = new WalletConnectConnector(
         network,
+        feeCurrency,
         {
           connect: {
             metadata: {

--- a/packages/use-contractkit/src/contract-kit-provider.tsx
+++ b/packages/use-contractkit/src/contract-kit-provider.tsx
@@ -94,7 +94,7 @@ export const ContractKitProvider: React.FC<ContractKitProviderProps> = ({
   dapp,
   network = Mainnet,
   networks = DEFAULT_NETWORKS,
-  feeCurrency = CeloContract.StableToken,
+  feeCurrency = CeloContract.GoldToken,
 }: ContractKitProviderProps) => {
   const isMountedRef = useIsMounted();
   const previousConfig = useMemo(loadPreviousConfig, []);

--- a/packages/use-contractkit/src/contract-kit-provider.tsx
+++ b/packages/use-contractkit/src/contract-kit-provider.tsx
@@ -1,3 +1,4 @@
+import { CeloContract, CeloTokenContract } from '@celo/contractkit';
 import React, {
   ReactNode,
   useCallback,
@@ -62,6 +63,7 @@ const initialState = {
   pendingActionCount: 0,
   address: null,
   connectionCallback: null,
+  feeCurrency: CeloContract.GoldToken,
 };
 
 export const [useContractKitContext, ContextProvider] =
@@ -92,6 +94,7 @@ export const ContractKitProvider: React.FC<ContractKitProviderProps> = ({
   dapp,
   network = Mainnet,
   networks = DEFAULT_NETWORKS,
+  feeCurrency = CeloContract.StableToken,
 }: ContractKitProviderProps) => {
   const isMountedRef = useIsMounted();
   const previousConfig = useMemo(loadPreviousConfig, []);
@@ -100,6 +103,7 @@ export const ContractKitProvider: React.FC<ContractKitProviderProps> = ({
     ...previousConfig,
     network,
     networks,
+    feeCurrency,
     dapp: {
       ...dapp,
       icon: dapp.icon ?? `${dapp.url}/favicon.ico`,
@@ -143,7 +147,7 @@ interface ContractKitProviderProps {
   dapp: Dapp;
   network?: Network;
   networks?: Network[];
-
+  feeCurrency?: CeloTokenContract;
   connectModal?: ConnectModalProps;
   actionModal?: {
     reactModalProps?: Partial<ReactModal.Props>;

--- a/packages/use-contractkit/src/contract-kit-reducer.ts
+++ b/packages/use-contractkit/src/contract-kit-reducer.ts
@@ -1,3 +1,4 @@
+import { CeloTokenContract } from '@celo/contractkit';
 import { UnauthenticatedConnector } from './connectors';
 import { localStorageKeys } from './constants';
 import { Connector, Dapp, Network } from './types';
@@ -42,7 +43,8 @@ export function contractKitReducer(
         connectorInitError: null,
         address: null,
       };
-
+    case 'setFeeCurrency':
+      return { ...state, feeCurrency: action.payload };
     case 'initialisedConnector': {
       const newConnector = action.payload;
       const address = newConnector.kit.defaultAccount ?? null;
@@ -95,6 +97,8 @@ export interface ReducerState {
   networks: Network[];
   pendingActionCount: number;
   address: string | null;
+  feeCurrency: CeloTokenContract;
+
   connectionCallback: ((connector: Connector | false) => void) | null;
 }
 

--- a/packages/use-contractkit/src/screens/cew.tsx
+++ b/packages/use-contractkit/src/screens/cew.tsx
@@ -8,10 +8,15 @@ import { ConnectorProps } from '.';
 export const CeloExtensionWallet: React.FC<ConnectorProps> = ({
   onSubmit,
 }: ConnectorProps) => {
-  const { network, initConnector, initError: error } = useContractKitInternal();
+  const {
+    network,
+    initConnector,
+    initError: error,
+    feeCurrency,
+  } = useContractKitInternal();
 
   const initialiseConnection = useCallback(async () => {
-    const connector = new CeloExtensionWalletConnector(network);
+    const connector = new CeloExtensionWalletConnector(network, feeCurrency);
     await initConnector(connector);
     void onSubmit(connector);
   }, [initConnector, network, onSubmit]);

--- a/packages/use-contractkit/src/screens/cew.tsx
+++ b/packages/use-contractkit/src/screens/cew.tsx
@@ -19,7 +19,7 @@ export const CeloExtensionWallet: React.FC<ConnectorProps> = ({
     const connector = new CeloExtensionWalletConnector(network, feeCurrency);
     await initConnector(connector);
     void onSubmit(connector);
-  }, [initConnector, network, onSubmit]);
+  }, [initConnector, network, onSubmit, feeCurrency]);
 
   useEffect(() => {
     void initialiseConnection();

--- a/packages/use-contractkit/src/screens/ledger.tsx
+++ b/packages/use-contractkit/src/screens/ledger.tsx
@@ -9,14 +9,23 @@ import { ConnectorProps } from '.';
 export const Ledger: React.FC<ConnectorProps> = ({
   onSubmit,
 }: ConnectorProps) => {
-  const { network, initConnector, initError: error } = useContractKitInternal();
+  const {
+    network,
+    initConnector,
+    initError: error,
+    feeCurrency,
+  } = useContractKitInternal();
   const [submitting, setSubmitting] = useState(false);
   const [index, setIndex] = useState('0');
   const isMountedRef = useIsMounted();
 
   const submit = async () => {
     setSubmitting(true);
-    const connector = new LedgerConnector(network, parseInt(index, 10));
+    const connector = new LedgerConnector(
+      network,
+      parseInt(index, 10),
+      feeCurrency
+    );
     try {
       await initConnector(connector);
       onSubmit(connector);

--- a/packages/use-contractkit/src/screens/private-key.tsx
+++ b/packages/use-contractkit/src/screens/private-key.tsx
@@ -8,14 +8,14 @@ export const PrivateKey: React.FC<ConnectorProps> = ({
   onSubmit,
 }: ConnectorProps) => {
   const [value, setValue] = useState('');
-  const { network } = useContractKit();
+  const { network, feeCurrency } = useContractKit();
 
   const handleSubmit = () => {
     if (!value) {
       return;
     }
 
-    const connector = new PrivateKeyConnector(network, value);
+    const connector = new PrivateKeyConnector(network, value, feeCurrency);
     void onSubmit(connector);
   };
 

--- a/packages/use-contractkit/src/types.ts
+++ b/packages/use-contractkit/src/types.ts
@@ -1,4 +1,4 @@
-import { ContractKit } from '@celo/contractkit';
+import { CeloTokenContract, ContractKit } from '@celo/contractkit';
 import React from 'react';
 
 import { NetworkNames, WalletTypes } from './constants';
@@ -43,11 +43,14 @@ export interface Connector {
   kit: ContractKit;
   type: WalletTypes;
   account: string | null;
+  feeCurrency: CeloTokenContract;
 
   initialised: boolean;
   initialise: () => Promise<this> | this;
   close: () => Promise<void> | void;
+  updateFeeCurrency: (token: CeloTokenContract) => Promise<void>;
 
+  updateKitWithNetwork?: (network: Network) => Promise<void>;
   onNetworkChange?: (callback: (chainId: number) => void) => void;
   onAddressChange?: (callback: (address: string | null) => void) => void;
 }

--- a/packages/use-contractkit/src/use-contract-kit-methods.ts
+++ b/packages/use-contractkit/src/use-contract-kit-methods.ts
@@ -151,7 +151,7 @@ export function useContractKitMethods(
       await connector.updateFeeCurrency(newFeeCurrency);
       dispatch('setFeeCurrency', newFeeCurrency);
     },
-    [feeCurrency, connector]
+    [connector, dispatch]
   );
 
   const performActions = useCallback(
@@ -184,6 +184,7 @@ export function useContractKitMethods(
     connect,
     getConnectedKit,
     performActions,
+    updateFeeCurrency,
   };
 }
 
@@ -196,4 +197,5 @@ export interface ContractKitMethods {
   performActions: (
     ...operations: ((kit: ContractKit) => unknown | Promise<unknown>)[]
   ) => Promise<unknown[]>;
+  updateFeeCurrency: (newFeeCurrency: CeloTokenContract) => Promise<void>;
 }

--- a/packages/use-contractkit/src/use-contract-kit-methods.ts
+++ b/packages/use-contractkit/src/use-contract-kit-methods.ts
@@ -57,7 +57,21 @@ export function useContractKitMethods(
                 .then(() => {
                   dispatch('initialisedConnector', initialisedConnector);
                 })
-                .catch((e) => console.log(e));
+                .catch((e) => {
+                  console.error(
+                    '[use-contractkit] Error switching network',
+                    nextConnector.type,
+                    e
+                  );
+                  const error =
+                    e instanceof Error
+                      ? e
+                      : new Error(
+                          `Failed to initialise connector with ${network.name}`
+                        );
+                  dispatch('setConnectorInitError', error);
+                  throw e;
+                });
           }
         });
         initialisedConnector.onAddressChange?.((address) => {

--- a/packages/use-contractkit/src/use-contract-kit-methods.ts
+++ b/packages/use-contractkit/src/use-contract-kit-methods.ts
@@ -54,9 +54,9 @@ export function useContractKitMethods(
             initialisedConnector.updateKitWithNetwork &&
               initialisedConnector
                 .updateKitWithNetwork(network)
-                .then(() =>
-                  dispatch('initialisedConnector', initialisedConnector)
-                )
+                .then(() => {
+                  dispatch('initialisedConnector', initialisedConnector);
+                })
                 .catch((e) => console.log(e));
           }
         });

--- a/packages/use-contractkit/src/use-contractkit.tsx
+++ b/packages/use-contractkit/src/use-contractkit.tsx
@@ -1,4 +1,4 @@
-import { ContractKit } from '@celo/contractkit';
+import { CeloTokenContract, ContractKit } from '@celo/contractkit';
 import { WalletTypes } from './constants';
 import { useContractKitContext } from './contract-kit-provider';
 import { Connector, Dapp, Network } from './types';
@@ -7,6 +7,7 @@ export interface UseContractKit {
   dapp: Dapp;
   kit: ContractKit;
   walletType: WalletTypes;
+  feeCurrency: CeloTokenContract;
 
   /**
    * Name of the account.
@@ -46,7 +47,7 @@ export interface UseContractKit {
 
 export const useContractKit = (): UseContractKit => {
   const [
-    { dapp, connector, connectorInitError, address, network },
+    { dapp, connector, connectorInitError, address, network, feeCurrency },
     _dispatch,
     { destroy, updateNetwork, connect, getConnectedKit, performActions },
   ] = useContractKitContext();
@@ -60,6 +61,7 @@ export const useContractKit = (): UseContractKit => {
     walletType: connector.type,
     account: connector.account,
     initialised: connector.initialised,
+    feeCurrency,
 
     performActions,
     getConnectedKit,

--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,12 @@ function App() {
 }
 ```
 
+### Adjust FeeCurrency
+
+use-contractkit provides a `feeCurrency` variable and an `updateFeeCurrency` function you can use to display the currently selected feeCurrency (cUSD, CELO, cEUR). The feeCurrency can also be passed to the provider component. Valid values are `CeloContract.GoldToken`, `CeloContract.StableToken`, `CeloContract.StableTokenEUR`. CeloContract can be imported like so:
+
+`import { CeloTokenContract } from '@celo/contractkit'`
+
 ### Dark mode
 
 use-contrackit uses Tailwind for styling, to use the modal in dark mode simply add the class `tw-dark` to the root `<html />` tag of the web page.


### PR DESCRIPTION
- fix a bug where changing network in metamask doesn't refresh the contractKit object
- add configurable feeCurrency