### PR TITLE
fix: Avoid blocking during WC v2 init

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "2.1.1-dev",
+  "version": "2.1.2-dev",
   "scripts": {
     "build": "next build",
     "clean": "rm -rf .next out",
@@ -12,11 +12,11 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@celo-tools/use-contractkit": "2.1.1-dev",
+    "@celo-tools/use-contractkit": "2.1.2-dev",
     "@celo/contractkit": "1.5.0",
     "@celo/utils": "1.5.0",
-    "@celo/wallet-walletconnect-v1": "2.1.1-dev",
-    "@celo/wallet-walletconnect": "2.1.1-dev",
+    "@celo/wallet-walletconnect-v1": "2.1.2-dev",
+    "@celo/wallet-walletconnect": "2.1.2-dev",
     "@ethersproject/providers": "^5.3.0",
     "@walletconnect/client-v1": "npm:@walletconnect/client@1.6.6",
     "autoprefixer": "^10.2.4",

--- a/packages/use-contractkit/package.json
+++ b/packages/use-contractkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo-tools/use-contractkit",
-  "version": "2.1.1-dev",
+  "version": "2.1.2-dev",
   "private": false,
   "scripts": {
     "build": "tsc -b && yarn run build-styles",
@@ -27,8 +27,8 @@
     "@celo/wallet-ledger": "1.5.0",
     "@celo/wallet-local": "1.5.0",
     "@celo/wallet-remote": "1.5.0",
-    "@celo/wallet-walletconnect": "2.1.1-dev",
-    "@celo/wallet-walletconnect-v1": "2.1.1-dev",
+    "@celo/wallet-walletconnect": "2.1.2-dev",
+    "@celo/wallet-walletconnect-v1": "2.1.2-dev",
     "@ethersproject/providers": "^5.3.0",
     "@ledgerhq/hw-transport-webusb": "^5.43.0",
     "@types/isomorphic-fetch": "^0.0.35",

--- a/packages/use-contractkit/src/connectors/useWalletConnectConnector.ts
+++ b/packages/use-contractkit/src/connectors/useWalletConnectConnector.ts
@@ -1,6 +1,5 @@
 import { SupportedMethods } from '@celo/wallet-walletconnect-v1';
 import { useEffect, useState } from 'react';
-
 import { Mainnet, WalletIds } from '../constants';
 import { Connector } from '../types';
 import { useContractKitInternal } from '../use-contractkit';
@@ -29,7 +28,6 @@ export function useWalletConnectConnector(
       }
 
       const isMainnet = network.name === Mainnet.name;
-      const relayUrl = 'wss://relay.walletconnect.org';
       const connector = new WalletConnectConnector(
         network,
         feeCurrency,
@@ -49,10 +47,6 @@ export function useWalletConnectConnector(
                 methods: Object.values(SupportedMethods),
               },
             },
-          },
-          init: {
-            relayUrl,
-            logger: 'error',
           },
         },
         autoOpen && isMainnet,

--- a/packages/use-contractkit/src/utils/useWalletVersion.ts
+++ b/packages/use-contractkit/src/utils/useWalletVersion.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-
 import { WalletIds } from '../constants';
 import fetchWCWallets from './fetchWCWallets';
 

--- a/packages/wallet-walletconnect/package.json
+++ b/packages/wallet-walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/wallet-walletconnect",
-  "version": "2.1.1-dev",
+  "version": "2.1.2-dev",
   "description": "WalletConnect wallet implementation",
   "author": "Celo",
   "license": "Apache-2.0",

--- a/packages/wallet-walletconnect/scripts/run-in-memory-client.ts
+++ b/packages/wallet-walletconnect/scripts/run-in-memory-client.ts
@@ -12,7 +12,6 @@ import { newKit } from '@celo/contractkit';
 //   verifySignature,
 // } from '@celo/utils/src/signatureUtils'
 import { WalletConnectWallet } from '../src';
-import { endpoint } from '../src/constants';
 
 async function main() {
   const name = `CLI DApp ${Math.random().toString().substring(12)}`;
@@ -25,10 +24,6 @@ async function main() {
         url: 'https://use-contractkit.vercel.app',
         icons: [],
       },
-    },
-    init: {
-      relayUrl: endpoint,
-      logger: 'error',
     },
   });
 

--- a/packages/wallet-walletconnect/src/constants.ts
+++ b/packages/wallet-walletconnect/src/constants.ts
@@ -1,1 +1,4 @@
-export const endpoint = 'wss://relay.walletconnect.org';
+// Using default relay: https://github.com/WalletConnect-Labs/walletconnect-v2-monorepo/blob/master/packages/client/src/constants/client.ts#L7
+export const RELAY_URL = 'wss://relay.walletconnect.com';
+// A project id registered for use-contractkit
+export const PROJECT_ID = '3ee9bf02f3a89a03837044fc7cdeb232';

--- a/packages/wallet-walletconnect/src/wc-wallet.ts
+++ b/packages/wallet-walletconnect/src/wc-wallet.ts
@@ -10,8 +10,7 @@ import {
 } from '@walletconnect/types/dist/cjs';
 import { ERROR } from '@walletconnect/utils';
 import debugConfig from 'debug';
-
-import { endpoint } from './constants';
+import { PROJECT_ID, RELAY_URL } from './constants';
 import { SupportedMethods, WalletConnectWalletOptions } from './types';
 import { parseAddress } from './utils';
 import { WalletConnectSigner } from './wc-signer';
@@ -40,7 +39,9 @@ async function waitForTruthy(getValue: () => boolean, attempts = 10) {
 }
 
 const defaultInitOptions: ClientOptions = {
-  relayUrl: endpoint,
+  relayUrl: RELAY_URL,
+  projectId: PROJECT_ID,
+  logger: 'error',
 };
 const defaultConnectOptions: ClientTypes.ConnectParams = {
   metadata: {
@@ -118,7 +119,9 @@ export class WalletConnectWallet extends RemoteWallet<WalletConnectSigner> {
     this.client.on(CLIENT_EVENTS.pairing.updated, this.onPairingUpdated);
     this.client.on(CLIENT_EVENTS.pairing.deleted, this.onPairingDeleted);
 
-    await this.client.connect(this.connectOptions);
+    this.client.connect(this.connectOptions)?.catch((e: Error) => {
+      console.error(`WalletConnect connection failed: ${e.message}`);
+    });
     await waitForTruthy(() => !!this.pairingProposal);
 
     return this.pairingProposal!.signal.params.uri;

--- a/packages/walletconnect-v1/package.json
+++ b/packages/walletconnect-v1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@celo/wallet-walletconnect-v1",
-  "version": "2.1.1-dev",
+  "version": "2.1.2-dev",
   "description": "WalletConnect wallet legacy (v1) implementation",
   "author": "Celo",
   "license": "Apache-2.0",
@@ -26,7 +26,7 @@
     "prepublishOnly": "yarn build"
   },
   "dependencies": {
-    "@celo/wallet-walletconnect": "2.1.1-dev",
+    "@celo/wallet-walletconnect": "2.1.2-dev",
     "@walletconnect/client-v1": "npm:@walletconnect/client@1.6.6",
     "@walletconnect/types-v1": "npm:@walletconnect/types@1.6.6",
     "@walletconnect/utils-v1": "npm:@walletconnect/utils@1.6.6",

--- a/packages/walletconnect-v1/src/constants.ts
+++ b/packages/walletconnect-v1/src/constants.ts
@@ -1,2 +1,1 @@
-export const endpoint = 'wss://relay.walletconnect.org';
 export const defaultBridge = 'https://bridge.walletconnect.org';

--- a/packages/walletconnect-v1/src/wc-wallet.ts
+++ b/packages/walletconnect-v1/src/wc-wallet.ts
@@ -10,7 +10,6 @@ import {
   IWalletConnectSDKOptions,
 } from '@walletconnect/types';
 import debugConfig from 'debug';
-
 import { defaultBridge } from './constants';
 import {
   AccountsProposal,
@@ -60,7 +59,7 @@ const defaultInitOptions: IWalletConnectSDKOptions = {
 };
 
 const defaultConnectOptions: ICreateSessionOptions = {
-  chainId: 44787,
+  chainId: 42220, // Celo Mainnet
 };
 
 export class WalletConnectWallet extends RemoteWallet<WalletConnectSigner> {


### PR DESCRIPTION
- Fix WC v2 init blocking issue
- Use 2.1.2-dev versions throughout packages
- Update relayUrl to match WalletConnect's default settings