### PR TITLE
Auto Switch to Valora (or other deeplinked wallet) when signing/approving on mobile

### DIFF
--- a/packages/use-contractkit/src/connectors/connectors.ts
+++ b/packages/use-contractkit/src/connectors/connectors.ts
@@ -353,7 +353,7 @@ export class WalletConnectConnector implements Connector {
     // options: WalletConnectWalletOptions | WalletConnectWalletOptionsV1,
     options: WalletConnectWalletOptionsV1,
     readonly autoOpen = false,
-    readonly getDeeplinkUrl?: (uri: string) => string,
+    public getDeeplinkUrl?: (uri: string) => string,
     readonly version?: number
   ) {
     localStorage.setItem(

--- a/packages/use-contractkit/src/types.ts
+++ b/packages/use-contractkit/src/types.ts
@@ -49,7 +49,7 @@ export interface Connector {
   initialise: () => Promise<this> | this;
   close: () => Promise<void> | void;
   updateFeeCurrency: (token: CeloTokenContract) => Promise<void>;
-
+  getDeeplinkUrl?: (uri: string) => string;
   updateKitWithNetwork?: (network: Network) => Promise<void>;
   onNetworkChange?: (callback: (chainId: number) => void) => void;
   onAddressChange?: (callback: (address: string | null) => void) => void;

--- a/packages/use-contractkit/src/use-contract-kit-methods.ts
+++ b/packages/use-contractkit/src/use-contract-kit-methods.ts
@@ -1,5 +1,6 @@
 import { CeloTokenContract, ContractKit } from '@celo/contractkit';
 import { useCallback } from 'react';
+import { isMobile } from 'react-device-detect';
 
 import { CONNECTOR_TYPES } from './connectors';
 import {
@@ -161,11 +162,15 @@ export function useContractKitMethods(
       ...operations: ((kit: ContractKit) => unknown | Promise<unknown>)[]
     ) => {
       const kit = await getConnectedKit();
-
       dispatch('setPendingActionCount', operations.length);
+
       const results: unknown[] = [];
       for (const op of operations) {
         try {
+          // When on mobile direct user to their wallet app.
+          if (isMobile && connector.getDeeplinkUrl) {
+            window.open(connector.getDeeplinkUrl(''), '_blank');
+          }
           results.push(await op(kit));
         } catch (e) {
           dispatch('setPendingActionCount', 0);
@@ -176,7 +181,7 @@ export function useContractKitMethods(
       }
       return results;
     },
-    [getConnectedKit, dispatch]
+    [getConnectedKit, dispatch, isMobile]
   );
 
   return {


### PR DESCRIPTION
When in mobile context and connected to a wallet that uses deeplinks auto switch to that wallet app.


fixes #108 