### PR TITLE
Precise celo/utils imports 

### DIFF
--- a/packages/wallet-walletconnect/src/utils/parse-addresses.ts
+++ b/packages/wallet-walletconnect/src/utils/parse-addresses.ts
@@ -1,4 +1,4 @@
-import { AddressUtils } from '@celo/utils';
+import { isValidAddress } from '@celo/utils/lib/address';
 
 interface AddressWithNetwork {
   address: string;
@@ -12,7 +12,7 @@ function invalidChain(chain: string) {
 // celo:0x123
 function parseShortNameAddress(addressLike: string) {
   const [celo, address] = addressLike.split(':');
-  if (invalidChain(celo) || !AddressUtils.isValidAddress(address)) {
+  if (invalidChain(celo) || !isValidAddress(address)) {
     throw new Error('Invalid short name address');
   }
 
@@ -26,7 +26,7 @@ function parseShortNameAddress(addressLike: string) {
 function parseCaip50Address(addressLike: string) {
   const [address, chain, networkId] = addressLike.split(/[@:]/);
 
-  if (!AddressUtils.isValidAddress(address) || invalidChain(chain)) {
+  if (!isValidAddress(address) || invalidChain(chain)) {
     throw new Error(`Invalid CAIP50 address ${address}`);
   }
 
@@ -39,7 +39,7 @@ function parseCaip50Address(addressLike: string) {
 function parseCaip10Address(addressLike: string) {
   const [chain, networkId, address] = addressLike.split(':');
 
-  if (!AddressUtils.isValidAddress(address) || invalidChain(chain)) {
+  if (!isValidAddress(address) || invalidChain(chain)) {
     throw new Error(`Invalid CAIP10 address ${address}`);
   }
 

--- a/packages/walletconnect-v1/src/utils/parse-addresses.ts
+++ b/packages/walletconnect-v1/src/utils/parse-addresses.ts
@@ -1,4 +1,4 @@
-import { AddressUtils } from '@celo/utils';
+import { isValidAddress } from '@celo/utils/lib/address';
 
 interface AddressWithNetwork {
   address: string;
@@ -12,12 +12,7 @@ function invalidChain(chain: string) {
 // celo:0x123
 function parseShortNameAddress(addressLike: string) {
   const [celo, address] = addressLike.split(':');
-  if (
-    !celo ||
-    !address ||
-    invalidChain(celo) ||
-    !AddressUtils.isValidAddress(address)
-  ) {
+  if (!celo || !address || invalidChain(celo) || !isValidAddress(address)) {
     throw new Error('Invalid short name address');
   }
 
@@ -31,12 +26,7 @@ function parseShortNameAddress(addressLike: string) {
 function parseCaip50Address(addressLike: string) {
   const [address, chain, networkId] = addressLike.split(/[@:]/);
 
-  if (
-    !chain ||
-    !address ||
-    !AddressUtils.isValidAddress(address) ||
-    invalidChain(chain)
-  ) {
+  if (!chain || !address || !isValidAddress(address) || invalidChain(chain)) {
     throw new Error(
       `Invalid CAIP50 address ${address || '<undefined address>'}`
     );
@@ -51,12 +41,7 @@ function parseCaip50Address(addressLike: string) {
 function parseCaip10Address(addressLike: string) {
   const [chain, networkId, address] = addressLike.split(':');
 
-  if (
-    !address ||
-    !chain ||
-    !AddressUtils.isValidAddress(address) ||
-    invalidChain(chain)
-  ) {
+  if (!address || !chain || !isValidAddress(address) || invalidChain(chain)) {
     throw new Error(
       `Invalid CAIP10 address ${address || '<undefined address>'}`
     );


### PR DESCRIPTION
Everywhere else we are importing celo/utils specific folders and functions. Thought it would be good to be consistent.


I believe this might make it more likely for bundle size to be kept down as just the used functions are imported. 