### PR TITLE
Fix bug where passing in custom rpc url got reset

### DIFF
--- a/packages/use-contractkit/src/contract-kit-provider.tsx
+++ b/packages/use-contractkit/src/contract-kit-provider.tsx
@@ -98,7 +98,7 @@ export const ContractKitProvider: React.FC<ContractKitProviderProps> = ({
 }: ContractKitProviderProps) => {
   const isMountedRef = useIsMounted();
   const previousConfig = useMemo(
-    () => loadPreviousConfig(network, feeCurrency),
+    () => loadPreviousConfig(network, feeCurrency, networks),
     // We only want this to run on mount so the deps array is empty.
     /* eslint-disable-next-line */
     []

--- a/packages/use-contractkit/src/utils/helpers.ts
+++ b/packages/use-contractkit/src/utils/helpers.ts
@@ -1,18 +1,14 @@
 import { CeloContract, CeloTokenContract } from '@celo/contractkit';
 
 import { CONNECTOR_TYPES, UnauthenticatedConnector } from '../connectors';
-import {
-  DEFAULT_NETWORKS,
-  localStorageKeys,
-  NetworkNames,
-  WalletTypes,
-} from '../constants';
+import { localStorageKeys, NetworkNames, WalletTypes } from '../constants';
 import { Connector, Network } from '../types';
 import localStorage from './localStorage';
 
 export const loadPreviousConfig = (
   defaultNetworkProp: Network,
-  defaultFeeCurrencyProp: CeloTokenContract
+  defaultFeeCurrencyProp: CeloTokenContract,
+  networks: Network[]
 ): {
   address: string | null;
   network: Network | null;
@@ -64,9 +60,7 @@ export const loadPreviousConfig = (
     }
   }
 
-  const lastUsedNetwork = DEFAULT_NETWORKS.find(
-    (n) => n.name === lastUsedNetworkName
-  );
+  const lastUsedNetwork = networks.find((n) => n.name === lastUsedNetworkName);
 
   let initialConnector: Connector;
   if (lastUsedWalletType && lastUsedNetwork) {


### PR DESCRIPTION
Rather than finding in DEFAULT_NETWORKS instead look in passed networks array. 


fixes https://github.com/celo-org/use-contractkit/issues/134


Note this does require the networks passed into ContractKitProvider to be consistent 