### PR TITLE
Fixes #130 - connect to dapp with metamask mobile app

### DIFF
--- a/packages/use-contractkit/src/constants.tsx
+++ b/packages/use-contractkit/src/constants.tsx
@@ -84,7 +84,13 @@ export const PROVIDERS: {
   },
   [SupportedProviders.MetaMask]: {
     name: SupportedProviders.MetaMask,
-    description: (
+    description: isMobile ? (
+      isEthereumFromMetamask() ? (
+        'Connect with MetaMask Mobile App'
+      ) : (
+        'Open MetaMask Mobile App'
+      )
+    ) : (
       <>
         Use the Metamask browser extension. Celo support is limited.{' '}
         <a
@@ -103,7 +109,7 @@ export const PROVIDERS: {
     ),
     icon: METAMASK,
     canConnect: () => isEthereumFromMetamask(),
-    showInList: () => !isMobile,
+    showInList: () => true,
     listPriority: () => 0,
     installURL: 'https://metamask.app.link/',
   },

--- a/packages/use-contractkit/src/utils/metamask.ts
+++ b/packages/use-contractkit/src/utils/metamask.ts
@@ -75,6 +75,7 @@ export interface AddEthereumChainParameter {
 
 export enum MetamaskRPCErrorCode {
   AwaitingUserConfirmation = -32002,
+  UnrecognizedChainID = -32603, // this is the error that shows up on metamask mobile
   UnknownNetwork = 4902,
 }
 
@@ -215,7 +216,10 @@ export async function switchToCeloNetwork(
       });
     } catch (err) {
       const { code } = err as MetamaskRPCError;
-      if (code === MetamaskRPCErrorCode.UnknownNetwork) {
+      if (
+        code === MetamaskRPCErrorCode.UnknownNetwork ||
+        code === MetamaskRPCErrorCode.UnrecognizedChainID
+      ) {
         // ChainId not yet added to metamask
         await addNetworkToMetamask(ethereum, network);
         return switchToCeloNetwork(kit, network, ethereum);


### PR DESCRIPTION
# What
Adds Support for connecting via Metamask mobile app

# WHY

If Celo is mobile focused we should support mobile apps for connecting

#HOW

Removed the conditional preventing it from showing on mobile and updated wording, updated copy. 

Also fixed issue with error being thrown when MMM did not have the network i was connecting to

# tested

on iPhone on Alfajores 

Fixes #130 