### PR TITLE
chore: Label all issues in repo as Applications so they show in zenhub

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+Applications:
+  - '*'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,15 @@
+name: 'Issue Labeler'
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v2.0
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          configuration-path: .github/labeler.yml
+          not-before: 2020-01-15T02:54:32Z
+          enable-versioned-regex: 0


### PR DESCRIPTION
Any time an issue is created it will be given the Applications Label. 

This means it will showup in the zenhub board which filters by label due to monorepo 