### PR TITLE
FEAT: Allow developers to pass in any networks they wish (and fix feeCurrency)

### DIFF
--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -4,10 +4,14 @@ import '../styles/global.css';
 import {
   Alfajores,
   ContractKitProvider,
+  DEFAULT_NETWORKS,
+  NetworkNames,
   Provider,
 } from '@celo-tools/use-contractkit';
 import { AppProps } from 'next/app';
 import { Toaster } from 'react-hot-toast';
+
+const ExtendedNetworkNames = { Ethereum: 'Ethereum', ...NetworkNames };
 
 function MyApp({ Component, pageProps, router }: AppProps): React.ReactElement {
   if (router.route === '/wallet') {
@@ -23,6 +27,15 @@ function MyApp({ Component, pageProps, router }: AppProps): React.ReactElement {
         icon: 'https://use-contractkit.vercel.app/favicon.ico',
       }}
       network={Alfajores}
+      networks={[
+        {
+          name: ExtendedNetworkNames.Ethereum,
+          rpcUrl: 'https://api.mycryptoapi.com/eth',
+          explorer: 'https://etherscan.io/',
+          chainId: 1,
+        },
+        ...DEFAULT_NETWORKS,
+      ]}
       connectModal={{
         title: <span>Connect your DummyWallet</span>,
         providersOptions: {

--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -4,14 +4,10 @@ import '../styles/global.css';
 import {
   Alfajores,
   ContractKitProvider,
-  DEFAULT_NETWORKS,
-  NetworkNames,
   Provider,
 } from '@celo-tools/use-contractkit';
 import { AppProps } from 'next/app';
 import { Toaster } from 'react-hot-toast';
-
-const ExtendedNetworkNames = { Ethereum: 'Ethereum', ...NetworkNames };
 
 function MyApp({ Component, pageProps, router }: AppProps): React.ReactElement {
   if (router.route === '/wallet') {
@@ -27,15 +23,6 @@ function MyApp({ Component, pageProps, router }: AppProps): React.ReactElement {
         icon: 'https://use-contractkit.vercel.app/favicon.ico',
       }}
       network={Alfajores}
-      networks={[
-        {
-          name: ExtendedNetworkNames.Ethereum,
-          rpcUrl: 'https://api.mycryptoapi.com/eth',
-          explorer: 'https://etherscan.io/',
-          chainId: 1,
-        },
-        ...DEFAULT_NETWORKS,
-      ]}
       connectModal={{
         title: <span>Connect your DummyWallet</span>,
         providersOptions: {

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -48,6 +48,7 @@ export default function Home(): React.ReactElement {
     networks,
     updateNetwork,
     connect,
+    supportsFeeCurrency,
     destroy,
     performActions,
     walletType,
@@ -386,9 +387,11 @@ export default function Home(): React.ReactElement {
                 </div>
                 <div>
                   <div className="text-lg font-bold mb-2 text-gray-900">
-                    Fee Currency
+                    Fee Currency{' '}
+                    {supportsFeeCurrency || `not supported on ${walletType}`}
                   </div>
                   <select
+                    disabled={!supportsFeeCurrency}
                     value={feeCurrency}
                     onChange={(event) =>
                       updateFeeCurrency(event.target.value as CeloTokenContract)

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -2,12 +2,7 @@ import { CeloContract, CeloTokenContract } from '@celo/contractkit';
 import { StableToken } from '@celo/contractkit/lib/celo-tokens';
 import { StableTokenWrapper } from '@celo/contractkit/lib/wrappers/StableTokenWrapper';
 import { ensureLeading0x } from '@celo/utils/lib/address';
-import {
-  Alfajores,
-  Baklava,
-  Mainnet,
-  useContractKit,
-} from '@celo-tools/use-contractkit';
+import { useContractKit } from '@celo-tools/use-contractkit';
 import { BigNumber } from 'bignumber.js';
 import Head from 'next/head';
 import { useCallback, useEffect, useState } from 'react';
@@ -45,13 +40,12 @@ function truncateAddress(address: string) {
   return `${address.slice(0, 8)}...${address.slice(36)}`;
 }
 
-const networks = [Alfajores, Baklava, Mainnet];
-
 export default function Home(): React.ReactElement {
   const {
     kit,
     address,
     network,
+    networks,
     updateNetwork,
     connect,
     destroy,
@@ -360,7 +354,7 @@ export default function Home(): React.ReactElement {
               <div className="w-64 md:w-96 space-y-4 text-gray-700">
                 <div className="mb-4">
                   <div className="text-lg font-bold mb-2 text-gray-900">
-                    Account summary
+                    Account Summary on {network.name}
                   </div>
                   <div className="space-y-2">
                     <div>Wallet type: {walletType}</div>

--- a/packages/use-contractkit/src/connectors/connectors.ts
+++ b/packages/use-contractkit/src/connectors/connectors.ts
@@ -412,7 +412,12 @@ export class WalletConnectConnector implements Connector {
   }
 
   supportsFeeCurrency() {
-    return this.version !== 1; // TODO when version 2 will need to figure this out wallet by wallet with a whitelist
+    // If on WC 1 it will not work due to fields being dropped
+    if (!this.version || this.version === 1) {
+      return false;
+    }
+    // TODO when V2 is used again check based on wallet?
+    return true;
   }
 
   private async fetchWalletAddressForAccount(address?: string) {

--- a/packages/use-contractkit/src/constants.tsx
+++ b/packages/use-contractkit/src/constants.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { isMobile } from 'react-device-detect';
 
-import { ChainId, Provider } from './types';
+import { ChainId, Network, Provider } from './types';
 import { isEthereumFromMetamask, isEthereumPresent } from './utils/ethereum';
 import {
   CELO,
@@ -187,14 +187,14 @@ export const images = {
   [SupportedProviders.PrivateKey]: PRIVATE_KEY,
 } as const;
 
-export enum NetworkNames {
-  Alfajores = 'Alfajores',
-  Baklava = 'Baklava',
-  Mainnet = 'Mainnet',
-  Localhost = 'Localhost',
-}
+export const NetworkNames = {
+  Alfajores: 'Alfajores' as const,
+  Baklava: 'Baklava' as const,
+  Mainnet: 'Mainnet' as const,
+  Localhost: 'Localhost' as const,
+};
 
-export const Alfajores = {
+export const Alfajores: Network = {
   name: NetworkNames.Alfajores,
   rpcUrl: 'https://alfajores-forno.celo-testnet.org',
   graphQl: 'https://alfajores-blockscout.celo-testnet.org/graphiql',
@@ -202,7 +202,7 @@ export const Alfajores = {
   chainId: ChainId.Alfajores,
 } as const;
 
-export const Baklava = {
+export const Baklava: Network = {
   name: NetworkNames.Baklava,
   rpcUrl: 'https://baklava-forno.celo-testnet.org',
   graphQl: 'https://baklava-blockscout.celo-testnet.org/graphiql',
@@ -210,7 +210,7 @@ export const Baklava = {
   chainId: ChainId.Baklava,
 } as const;
 
-export const Mainnet = {
+export const Mainnet: Network = {
   name: NetworkNames.Mainnet,
   rpcUrl: 'https://forno.celo.org',
   graphQl: 'https://explorer.celo.org/graphiql',
@@ -218,7 +218,7 @@ export const Mainnet = {
   chainId: ChainId.Mainnet,
 } as const;
 
-export const Localhost = {
+export const Localhost: Network = {
   name: NetworkNames.Localhost,
   rpcUrl: 'http://localhost:8545',
   graphQl: '',

--- a/packages/use-contractkit/src/types.ts
+++ b/packages/use-contractkit/src/types.ts
@@ -1,7 +1,7 @@
 import { CeloTokenContract, ContractKit } from '@celo/contractkit';
 import React from 'react';
 
-import { NetworkNames, WalletIds, WalletTypes } from './constants';
+import { WalletIds, WalletTypes } from './constants';
 
 /**
  * ID of a Celo chain.
@@ -16,10 +16,19 @@ export enum ChainId {
  * Network connection information.
  */
 export interface Network {
-  name: NetworkNames;
+  name: string;
   rpcUrl: string;
-  graphQl: string;
+  graphQl?: string;
   explorer: string;
+  chainId: ChainId | number;
+  nativeCurrency?: {
+    name: string;
+    symbol: string;
+    decimals: number;
+  };
+}
+
+export interface CeloNetwork extends Network {
   chainId: ChainId;
 }
 

--- a/packages/use-contractkit/src/types.ts
+++ b/packages/use-contractkit/src/types.ts
@@ -54,11 +54,11 @@ export interface Connector {
   type: WalletTypes;
   account: string | null;
   feeCurrency: CeloTokenContract;
-
   initialised: boolean;
   initialise: () => Promise<this> | this;
   close: () => Promise<void> | void;
-  updateFeeCurrency: (token: CeloTokenContract) => Promise<void>;
+  updateFeeCurrency?: (token: CeloTokenContract) => Promise<void>;
+  supportsFeeCurrency: () => boolean;
   getDeeplinkUrl?: (uri: string) => string;
   updateKitWithNetwork?: (network: Network) => Promise<void>;
   onNetworkChange?: (callback: (chainId: number) => void) => void;

--- a/packages/use-contractkit/src/use-contract-kit-methods.ts
+++ b/packages/use-contractkit/src/use-contract-kit-methods.ts
@@ -1,4 +1,9 @@
-import { CeloTokenContract, ContractKit } from '@celo/contractkit';
+import {
+  CeloContract,
+  CeloTokenContract,
+  CeloTokens,
+  ContractKit,
+} from '@celo/contractkit';
 import { useCallback } from 'react';
 import { isMobile } from 'react-device-detect';
 
@@ -150,8 +155,17 @@ export function useContractKitMethods(
 
   const updateFeeCurrency = useCallback(
     async (newFeeCurrency: CeloTokenContract): Promise<void> => {
-      await connector.updateFeeCurrency(newFeeCurrency);
-      dispatch('setFeeCurrency', newFeeCurrency);
+      try {
+        if (connector.supportsFeeCurrency() && connector.updateFeeCurrency) {
+          await connector.updateFeeCurrency(newFeeCurrency);
+          dispatch('setFeeCurrency', newFeeCurrency);
+        }
+      } catch (error) {
+        console.warn(
+          'updating Fee Currency not supported by this wallet or network',
+          error
+        );
+      }
     },
     [connector, dispatch]
   );

--- a/packages/use-contractkit/src/use-contract-kit-methods.ts
+++ b/packages/use-contractkit/src/use-contract-kit-methods.ts
@@ -1,9 +1,4 @@
-import {
-  CeloContract,
-  CeloTokenContract,
-  CeloTokens,
-  ContractKit,
-} from '@celo/contractkit';
+import { CeloTokenContract, ContractKit } from '@celo/contractkit';
 import { useCallback } from 'react';
 import { isMobile } from 'react-device-detect';
 

--- a/packages/use-contractkit/src/use-contractkit.tsx
+++ b/packages/use-contractkit/src/use-contractkit.tsx
@@ -22,7 +22,7 @@ export interface UseContractKit {
   networks: readonly Network[];
   updateNetwork: (network: Network) => Promise<void>;
   updateFeeCurrency: (newFeeCurrency: CeloTokenContract) => Promise<void>;
-
+  supportsFeeCurrency: boolean;
   /**
    * Helper function for handling any interaction with a Celo wallet. Perform action will
    * - open the action modal
@@ -83,6 +83,7 @@ export const useContractKit = (): UseContractKit => {
     initialised: connector.initialised,
     feeCurrency,
     updateFeeCurrency,
+    supportsFeeCurrency: connector.supportsFeeCurrency(),
     performActions,
     getConnectedKit,
     connect,

--- a/packages/use-contractkit/src/use-contractkit.tsx
+++ b/packages/use-contractkit/src/use-contractkit.tsx
@@ -19,6 +19,7 @@ export interface UseContractKit {
   connect: () => Promise<Connector>;
   destroy: () => Promise<void>;
   network: Network;
+  networks: readonly Network[];
   updateNetwork: (network: Network) => Promise<void>;
   updateFeeCurrency: (newFeeCurrency: CeloTokenContract) => Promise<void>;
 
@@ -49,7 +50,15 @@ export interface UseContractKit {
 
 export const useContractKit = (): UseContractKit => {
   const [
-    { dapp, connector, connectorInitError, address, network, feeCurrency },
+    {
+      dapp,
+      connector,
+      connectorInitError,
+      address,
+      network,
+      feeCurrency,
+      networks,
+    },
     _dispatch,
     {
       destroy,
@@ -65,14 +74,15 @@ export const useContractKit = (): UseContractKit => {
     address,
     dapp,
     network,
-    updateFeeCurrency,
+    // Copy to ensure any accidental mutations dont affect global state
+    networks: networks.map((net) => ({ ...net })),
     updateNetwork,
     kit: connector.kit,
     walletType: connector.type,
     account: connector.account,
     initialised: connector.initialised,
     feeCurrency,
-
+    updateFeeCurrency,
     performActions,
     getConnectedKit,
     connect,

--- a/packages/use-contractkit/src/utils/helpers.ts
+++ b/packages/use-contractkit/src/utils/helpers.ts
@@ -1,7 +1,7 @@
 import { CeloContract, CeloTokenContract } from '@celo/contractkit';
 
 import { CONNECTOR_TYPES, UnauthenticatedConnector } from '../connectors';
-import { localStorageKeys, NetworkNames, WalletTypes } from '../constants';
+import { localStorageKeys, WalletTypes } from '../constants';
 import { Connector, Network } from '../types';
 import localStorage from './localStorage';
 
@@ -15,7 +15,7 @@ export const loadPreviousConfig = (
   connector: Connector;
   feeCurrency: CeloTokenContract | null;
 } => {
-  let lastUsedNetworkName: NetworkNames = defaultNetworkProp.name;
+  let lastUsedNetworkName = defaultNetworkProp.name;
   let lastUsedAddress: string | null = null;
   let lastUsedWalletType: WalletTypes = WalletTypes.Unauthenticated;
   let lastUsedWalletArguments: unknown[] = [];
@@ -25,7 +25,7 @@ export const loadPreviousConfig = (
       localStorageKeys.lastUsedNetwork
     );
     if (localLastUsedNetworkName) {
-      lastUsedNetworkName = localLastUsedNetworkName as NetworkNames;
+      lastUsedNetworkName = localLastUsedNetworkName;
     }
 
     lastUsedAddress = localStorage.getItem(localStorageKeys.lastUsedAddress);

--- a/readme.md
+++ b/readme.md
@@ -319,7 +319,7 @@ function App() {
 
 #### Extending Supported Networks
 
-By default Use-Contractkit only supports Celo Blockchain Networks. You can however extend this to include other chains you choose such as Ethereum, Polygon, Avalanche etc by Passing your array of `Network`s into `ContractKitProvider`.
+By default Use-Contractkit only supports Celo Blockchain Networks. You can however extend this to include other chains you choose such as Ethereum, Polygon, Avalanche etc by Passing your array of `Network`s into `ContractKitProvider`. Note this feature is considered experimental and works better with wallets like Metamask.
 
 ### Adjust FeeCurrency
 

--- a/readme.md
+++ b/readme.md
@@ -302,6 +302,7 @@ function WrappedApp({ Component, pageProps }) {
 function App () {
   ...
 }
+
 ```
 
 Be sure to check the use-contractkit example application for a showcase of how network management works in more depth. Usually you'll want to show a dropdown to your users allowing them to select the network to connect to.
@@ -315,6 +316,10 @@ function App() {
   return <div>Currently connected to {network}</div>;
 }
 ```
+
+#### Extending Supported Networks
+
+By default Use-Contractkit only supports Celo Blockchain Networks. You can however extend this to include other chains you choose such as Ethereum, Polygon, Avalanche etc by Passing your array of `Network`s into `ContractKitProvider`.
 
 ### Adjust FeeCurrency
 


### PR DESCRIPTION
- add passed networks as a return value of useContractKit
- replace NetWorkNames Enum with POJO so that its extendable
- Make Network interface support arbitrary networks and include option to pass in the nativeCurrency which is used when adding to metamask.
- For non celo networks dont try to add celo tokens to metamask

- fix: updateFeeCurrency should only be an option for Connectors / wallets that support alternative  gas fee currencies	
 