### PR TITLE
Append current browser location in Metamask mobile

### DIFF
--- a/packages/use-contractkit/src/constants.tsx
+++ b/packages/use-contractkit/src/constants.tsx
@@ -131,7 +131,10 @@ export const PROVIDERS: {
     canConnect: () => isEthereumFromMetamask(),
     showInList: () => true,
     listPriority: () => 0,
-    installURL: 'https://metamask.app.link/',
+    installURL: isMobile
+      ? 'https://metamask.app.link/dapp/' +
+        window.location.href.replace(/^https?:\/\//, '')
+      : 'https://metamask.app.link/',
   },
   [SupportedProviders.CeloExtensionWallet]: {
     name: SupportedProviders.CeloExtensionWallet,


### PR DESCRIPTION
For the Metamask Supported Provider install URL, if on mobile, append the current browser location to `https://metamask.app.link/dapp/`