### PR TITLE
Breaking Change: Replace full ContractKit with MiniContractKit

### DIFF
--- a/contract-cache-recipes.md
+++ b/contract-cache-recipes.md
@@ -1,0 +1,49 @@
+# Building a Contracts Cache
+
+With version 4 the full ContractKit is no longer provided instead MiniContractKit is returned from the hook. For dapps that were accessing contract wrappers not provided on MiniContractKit getting the full contractsCache back can be done by providing a buildContractsCache function that takes in a `Connection` and an `AddressRegistry`. The return value of this function will be memoized and returned on `useContractKit` hook as `contractsCache`.
+
+## Getting back the full cache
+
+```typescript
+import { Web3ContractCache } from '@celo/contractkit/lib/web3-contract-cache';
+import { WrapperCache } from '@celo/contractkit/lib/contract-cache';
+import { AddressRegistry } from '@celo/contractkit/lib/address-registry';
+import { ContractKit } from '@celo/contractkit';
+
+// This creates a contracts cache exactly the same as contractkit.contracts
+function fullContractsCache(
+  connection: ContractKit['connection'],
+  registry: AddressRegistry
+) {
+  const web3Contracts = new Web3ContractCache(registry);
+  return new WrapperCache(connection, web3Contracts, registry);
+}
+```
+
+```tsx
+//
+<ContractKitProvider
+  // The result of this function will be memoized. it will be recalculated when `fullContractsCache`, `connection` or `addressRegistry` changes
+  buildContractsCache={fullContractsCache}
+>
+  {/* etc */}
+</ContractKitProvider>
+
+//
+```
+
+```ts
+import { useContractKit } from '@celo-tools/use-contractkit';
+
+const { contractsCache } = useContractKit();
+
+const contracts = contractsCache as WrapperCache;
+
+const governance = contractsCache.getGovernance();
+```
+
+## Creating a Custom Contracts Cache
+
+You can also create your own ContractsCache Class see [MiniContractsCache for an example](https://github.com/celo-org/celo-monorepo/blob/5cfd16214ca7ef7a7ff428c7d397933b3e1eeb51/packages/sdk/contractkit/src/mini-contract-cache.ts)
+
+Note that a few wrappers require a contractCache with a certain subset of other wrappers to be passed in to function these are `Slashers` `Election` `Governance` `ReleaseGold` `Validators` which depend on `Accounts` `Multisig` `BlockchainParameters` and themselves.

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -107,8 +107,8 @@ export default function Home(): React.ReactElement {
             Web3.utils.toWei('0.00000001', 'ether')
           )
           .sendAndWaitForReceipt({
-            from: k.defaultAccount,
-            gasPrice: k.gasPrice,
+            from: k.connection.defaultAccount,
+            gasPrice: k.connection.defaultGasPrice,
           });
       });
 
@@ -125,8 +125,11 @@ export default function Home(): React.ReactElement {
     setSending(true);
     try {
       await performActions(async (k) => {
-        if (k.defaultAccount) {
-          return await k.signTypedData(k.defaultAccount, TYPED_DATA);
+        if (k.connection.defaultAccount) {
+          return await k.connection.signTypedData(
+            k.connection.defaultAccount,
+            TYPED_DATA
+          );
         } else {
           throw new Error('No default account');
         }
@@ -143,12 +146,12 @@ export default function Home(): React.ReactElement {
     setSending(true);
     try {
       await performActions(async (k) => {
-        if (!k.defaultAccount) {
+        if (!k.connection.defaultAccount) {
           throw new Error('No default account');
         }
         return await k.connection.sign(
           ensureLeading0x(Buffer.from('Hello').toString('hex')),
-          k.defaultAccount
+          k.connection.defaultAccount
         );
       });
       toast.success('sign_personal succeeded');

--- a/packages/example/pages/wallet.tsx
+++ b/packages/example/pages/wallet.tsx
@@ -31,8 +31,7 @@ const kit = newKitFromWeb3(web3);
 const account = web3.eth.accounts.privateKeyToAccount(
   'e2d7138baa3a5600ac37984e40981591d7cf857bcadd7dc6f7d14023a17b0787'
 );
-kit.addAccount(account.privateKey);
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+kit.connection.addAccount(account.privateKey);
 const wallet = kit.getWallet()!;
 
 const defaultSummary = {

--- a/packages/example/pages/wallet.tsx
+++ b/packages/example/pages/wallet.tsx
@@ -1,4 +1,5 @@
 import { trimLeading0x } from '@celo/base';
+import { StableToken } from '@celo/contractkit/lib/celo-tokens';
 import { newKitFromWeb3 } from '@celo/contractkit/lib/mini-kit';
 import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils';
 import {

--- a/packages/example/pages/wallet.tsx
+++ b/packages/example/pages/wallet.tsx
@@ -1,5 +1,5 @@
 import { trimLeading0x } from '@celo/base';
-import { newKitFromWeb3, StableToken } from '@celo/contractkit';
+import { newKitFromWeb3 } from '@celo/contractkit/lib/mini-kit';
 import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils';
 import {
   AccountsProposal,

--- a/packages/use-contractkit/__tests__/utils/metamask.test.ts
+++ b/packages/use-contractkit/__tests__/utils/metamask.test.ts
@@ -1,4 +1,4 @@
-import { ContractKit, newKit } from '@celo/contractkit';
+import { MiniContractKit, newKit } from '@celo/contractkit/lib/mini-kit';
 import { GoldTokenWrapper } from '@celo/contractkit/lib/wrappers/GoldTokenWrapper';
 
 import { Alfajores } from '../../src';
@@ -20,7 +20,7 @@ import {
   tokenToParam,
 } from '../../src/utils/metamask';
 
-let kit: ContractKit;
+let kit: MiniContractKit;
 let CELO: GoldTokenWrapper;
 let tokens: StableTokens;
 

--- a/packages/use-contractkit/src/ContractCacheBuilder.tsx
+++ b/packages/use-contractkit/src/ContractCacheBuilder.tsx
@@ -1,0 +1,25 @@
+import { AddressRegistry } from '@celo/contractkit/lib/address-registry';
+import { MiniContractKit } from '@celo/contractkit/lib/mini-kit';
+import { useMemo } from 'react';
+
+import { Connector } from './types';
+
+export type ContractCacheBuilder<K = unknown> = (
+  connection: MiniContractKit['connection'],
+  registry: AddressRegistry
+) => K;
+
+export function useContractsCache(
+  buildContractsCache: ContractCacheBuilder | undefined,
+  connector: Connector
+) {
+  return useMemo(() => {
+    if (buildContractsCache) {
+      return buildContractsCache(
+        connector.kit.connection,
+        connector.kit.registry
+      );
+    }
+    return;
+  }, [buildContractsCache, connector.kit.connection, connector.kit.registry]);
+}

--- a/packages/use-contractkit/src/connectors/connectors.ts
+++ b/packages/use-contractkit/src/connectors/connectors.ts
@@ -445,5 +445,10 @@ async function updateFeeCurrency(
     return;
   }
   this.feeCurrency = feeContract;
-  await this.kit.setFeeCurrency(feeContract);
+  const address =
+    feeContract === CeloContract.GoldToken
+      ? undefined
+      : await this.kit.registry.addressFor(feeContract);
+
+  this.kit.connection.defaultFeeCurrency = address;
 }

--- a/packages/use-contractkit/src/connectors/connectors.ts
+++ b/packages/use-contractkit/src/connectors/connectors.ts
@@ -1,11 +1,10 @@
 import { ReadOnlyWallet } from '@celo/connect/lib';
+import { CeloContract, CeloTokenContract } from '@celo/contractkit/lib/base';
 import {
-  CeloContract,
-  CeloTokenContract,
-  ContractKit,
+  MiniContractKit,
   newKit,
   newKitFromWeb3,
-} from '@celo/contractkit';
+} from '@celo/contractkit/lib/mini-kit';
 import { LocalWallet } from '@celo/wallet-local';
 // Uncomment with WCV2 support
 // import {
@@ -36,7 +35,7 @@ type Web3Type = Parameters<typeof newKitFromWeb3>[0];
 export class UnauthenticatedConnector implements Connector {
   public initialised = true;
   public type = WalletTypes.Unauthenticated;
-  public kit: ContractKit;
+  public kit: MiniContractKit;
   public account: string | null = null;
   public feeCurrency: CeloTokenContract = CeloContract.GoldToken;
   constructor(n: Network) {
@@ -61,7 +60,7 @@ export class UnauthenticatedConnector implements Connector {
 export class PrivateKeyConnector implements Connector {
   public initialised = true;
   public type = WalletTypes.PrivateKey;
-  public kit: ContractKit;
+  public kit: MiniContractKit;
   public account: string | null = null;
 
   constructor(
@@ -83,8 +82,8 @@ export class PrivateKeyConnector implements Connector {
     wallet.addAccount(privateKey);
 
     this.kit = newKit(n.rpcUrl, wallet);
-    this.kit.defaultAccount = wallet.getAccounts()[0];
-    this.account = this.kit.defaultAccount ?? null;
+    this.kit.connection.defaultAccount = wallet.getAccounts()[0];
+    this.account = this.kit.connection.defaultAccount ?? null;
   }
 
   async initialise(): Promise<this> {
@@ -108,7 +107,7 @@ export class PrivateKeyConnector implements Connector {
 export class LedgerConnector implements Connector {
   public initialised = false;
   public type = WalletTypes.Ledger;
-  public kit: ContractKit;
+  public kit: MiniContractKit;
   public account: string | null = null;
 
   constructor(
@@ -137,10 +136,10 @@ export class LedgerConnector implements Connector {
     const transport = await TransportUSB.create();
     const wallet = await newLedgerWalletWithSetup(transport, [this.index]);
     this.kit = newKit(this.network.rpcUrl, wallet);
-    this.kit.defaultAccount = wallet.getAccounts()[0];
+    this.kit.connection.defaultAccount = wallet.getAccounts()[0];
 
     this.initialised = true;
-    this.account = this.kit.defaultAccount ?? null;
+    this.account = this.kit.connection.defaultAccount ?? null;
     await this.updateFeeCurrency(this.feeCurrency);
     return this;
   }
@@ -168,7 +167,7 @@ export class UnsupportedChainIdError extends Error {
 export class InjectedConnector implements Connector {
   public initialised = false;
   public type = WalletTypes.CeloExtensionWallet;
-  public kit: ContractKit;
+  public kit: MiniContractKit;
   public account: string | null = null;
   private onNetworkChangeCallback?: (chainId: number) => void;
   private onAddressChangeCallback?: (address: string | null) => void;
@@ -208,8 +207,8 @@ export class InjectedConnector implements Connector {
     ethereum.on('accountsChanged', this.onAccountsChanged);
 
     this.kit = newKitFromWeb3(web3 as unknown as Web3Type);
-    const [defaultAccount] = await this.kit.web3.eth.getAccounts();
-    this.kit.defaultAccount = defaultAccount;
+    const [defaultAccount] = await this.kit.connection.web3.eth.getAccounts();
+    this.kit.connection.defaultAccount = defaultAccount;
     this.account = defaultAccount ?? null;
     this.initialised = true;
 
@@ -225,7 +224,7 @@ export class InjectedConnector implements Connector {
 
   private onAccountsChanged = (accounts: string[]) => {
     if (this.onAddressChangeCallback) {
-      this.kit.defaultAccount = accounts[0];
+      this.kit.connection.defaultAccount = accounts[0];
       this.onAddressChangeCallback(accounts[0] ?? null);
     }
   };
@@ -269,7 +268,7 @@ export class MetaMaskConnector extends InjectedConnector {
 export class CeloExtensionWalletConnector implements Connector {
   public initialised = false;
   public type = WalletTypes.CeloExtensionWallet;
-  public kit: ContractKit;
+  public kit: MiniContractKit;
   public account: string | null = null;
   private onNetworkChangeCallback?: (chainId: number) => void;
 
@@ -312,8 +311,8 @@ export class CeloExtensionWalletConnector implements Connector {
     });
 
     this.kit = newKitFromWeb3(web3 as unknown as Web3Type);
-    const [defaultAccount] = await this.kit.web3.eth.getAccounts();
-    this.kit.defaultAccount = defaultAccount;
+    const [defaultAccount] = await this.kit.connection.web3.eth.getAccounts();
+    this.kit.connection.defaultAccount = defaultAccount;
     this.account = defaultAccount ?? null;
 
     this.initialised = true;
@@ -338,7 +337,7 @@ export class CeloExtensionWalletConnector implements Connector {
 export class WalletConnectConnector implements Connector {
   public initialised = false;
   public type = WalletTypes.WalletConnect;
-  public kit: ContractKit;
+  public kit: MiniContractKit;
   public account: string | null = null;
 
   private onUriCallback?: (uri: string) => void;
@@ -402,7 +401,7 @@ export class WalletConnectConnector implements Connector {
     await wallet.init();
     const [address] = wallet.getAccounts();
     const defaultAccount = await this.fetchWalletAddressForAccount(address);
-    this.kit.defaultAccount = defaultAccount;
+    this.kit.connection.defaultAccount = defaultAccount;
     this.account = defaultAccount ?? null;
 
     await this.updateFeeCurrency(this.feeCurrency);

--- a/packages/use-contractkit/src/contract-kit-provider.tsx
+++ b/packages/use-contractkit/src/contract-kit-provider.tsx
@@ -15,6 +15,7 @@ import {
   contractKitReducer,
   ReducerState,
 } from './contract-kit-reducer';
+import { ContractCacheBuilder } from './ContractCacheBuilder';
 import {
   ActionModal,
   ActionModalProps,
@@ -95,6 +96,7 @@ export const ContractKitProvider: React.FC<ContractKitProviderProps> = ({
   network = Mainnet,
   networks = DEFAULT_NETWORKS,
   feeCurrency = CeloContract.GoldToken,
+  buildContractsCache,
 }: ContractKitProviderProps) => {
   const isMountedRef = useIsMounted();
   const previousConfig = useMemo(
@@ -124,7 +126,7 @@ export const ContractKitProvider: React.FC<ContractKitProviderProps> = ({
     [isMountedRef]
   );
 
-  const methods = useContractKitMethods(state, dispatch);
+  const methods = useContractKitMethods(state, dispatch, buildContractsCache);
 
   useEffect(() => {
     if (CONNECTOR_TYPES[state.connector.type] !== UnauthenticatedConnector) {
@@ -152,6 +154,7 @@ interface ContractKitProviderProps {
   network?: Network;
   networks?: Network[];
   feeCurrency?: CeloTokenContract;
+  buildContractsCache?: ContractCacheBuilder;
   connectModal?: ConnectModalProps;
   actionModal?: {
     reactModalProps?: Partial<ReactModal.Props>;

--- a/packages/use-contractkit/src/contract-kit-provider.tsx
+++ b/packages/use-contractkit/src/contract-kit-provider.tsx
@@ -1,4 +1,4 @@
-import { CeloContract, CeloTokenContract } from '@celo/contractkit';
+import { CeloContract, CeloTokenContract } from '@celo/contractkit/lib/base';
 import React, {
   ReactNode,
   useCallback,

--- a/packages/use-contractkit/src/contract-kit-reducer.ts
+++ b/packages/use-contractkit/src/contract-kit-reducer.ts
@@ -1,4 +1,4 @@
-import { CeloTokenContract } from '@celo/contractkit';
+import { CeloTokenContract } from '@celo/contractkit/lib/base';
 
 import { UnauthenticatedConnector } from './connectors';
 import { localStorageKeys } from './constants';
@@ -62,7 +62,7 @@ export function contractKitReducer(
       return { ...state, feeCurrency: action.payload };
     case 'initialisedConnector': {
       const newConnector = action.payload;
-      const address = newConnector.kit.defaultAccount ?? null;
+      const address = newConnector.kit.connection.defaultAccount ?? null;
       if (address) {
         localStorage.setItem(localStorageKeys.lastUsedAddress, address);
       }

--- a/packages/use-contractkit/src/ethers.ts
+++ b/packages/use-contractkit/src/ethers.ts
@@ -7,7 +7,8 @@ import { useIsMounted } from './utils/useIsMounted';
 
 export const useProvider = (): Web3Provider => {
   const { kit, network } = useContractKit();
-  const provider = kit.web3.currentProvider as unknown as ExternalProvider;
+  const provider = kit.connection.web3
+    .currentProvider as unknown as ExternalProvider;
   const { chainId, name } = network;
   return useMemo(() => {
     return new Web3Provider(provider, { chainId, name });
@@ -18,10 +19,10 @@ export const useProviderOrSigner = (): Web3Provider | JsonRpcSigner => {
   const { kit } = useContractKit();
   const provider = useProvider();
   return useMemo(() => {
-    return kit.defaultAccount
-      ? provider.getSigner(kit.defaultAccount)
+    return kit.connection.defaultAccount
+      ? provider.getSigner(kit.connection.defaultAccount)
       : provider;
-  }, [provider, kit.defaultAccount]);
+  }, [provider, kit.connection.defaultAccount]);
 };
 
 export const useGetConnectedSigner = (): (() => Promise<JsonRpcSigner>) => {
@@ -30,17 +31,17 @@ export const useGetConnectedSigner = (): (() => Promise<JsonRpcSigner>) => {
   const { chainId, name } = network;
 
   return useCallback(async () => {
-    if (kit.defaultAccount) {
+    if (kit.connection.defaultAccount) {
       return signer as JsonRpcSigner;
     }
 
     const nextKit = await getConnectedKit();
-    const nextProvider = nextKit.web3
+    const nextProvider = nextKit.connection.web3
       .currentProvider as unknown as ExternalProvider;
     return new Web3Provider(nextProvider, { chainId, name }).getSigner(
-      nextKit.defaultAccount
+      nextKit.connection.defaultAccount
     );
-  }, [kit.defaultAccount, getConnectedKit, signer, chainId, name]);
+  }, [kit.connection.defaultAccount, getConnectedKit, signer, chainId, name]);
 };
 
 export const useLazyConnectedSigner = (): {

--- a/packages/use-contractkit/src/types.ts
+++ b/packages/use-contractkit/src/types.ts
@@ -1,4 +1,5 @@
-import { CeloTokenContract, ContractKit } from '@celo/contractkit';
+import { CeloTokenContract } from '@celo/contractkit/lib/base';
+import { MiniContractKit } from '@celo/contractkit/lib/mini-kit';
 import React from 'react';
 
 import { WalletIds, WalletTypes } from './constants';
@@ -50,7 +51,7 @@ export interface Provider {
  * Connects to the blockchain.
  */
 export interface Connector {
-  kit: ContractKit;
+  kit: MiniContractKit;
   type: WalletTypes;
   account: string | null;
   feeCurrency: CeloTokenContract;

--- a/packages/use-contractkit/src/use-contract-kit-methods.ts
+++ b/packages/use-contractkit/src/use-contract-kit-methods.ts
@@ -1,4 +1,5 @@
-import { CeloTokenContract, ContractKit } from '@celo/contractkit';
+import { CeloTokenContract } from '@celo/contractkit/lib/base';
+import { MiniContractKit } from '@celo/contractkit/lib/mini-kit';
 import { useCallback } from 'react';
 import { isMobile } from 'react-device-detect';
 
@@ -36,7 +37,8 @@ export function useContractKitMethods(
 
         // If the new wallet already has a specific network it's
         // using then we should go with that one.
-        const netId = await initialisedConnector.kit.web3.eth.net.getId();
+        const netId =
+          await initialisedConnector.kit.connection.web3.eth.net.getId();
         const newNetwork = networks.find((n) => netId === n.chainId);
         if (newNetwork !== network) {
           dispatch('setNetwork', network);
@@ -137,7 +139,7 @@ export function useContractKitMethods(
     return newConnector;
   }, [dispatch]);
 
-  const getConnectedKit = useCallback(async (): Promise<ContractKit> => {
+  const getConnectedKit = useCallback(async (): Promise<MiniContractKit> => {
     let initialisedConnection = connector;
     if (connector.type === WalletTypes.Unauthenticated) {
       initialisedConnection = await connect();
@@ -167,7 +169,7 @@ export function useContractKitMethods(
 
   const performActions = useCallback(
     async (
-      ...operations: ((kit: ContractKit) => unknown | Promise<unknown>)[]
+      ...operations: ((kit: MiniContractKit) => unknown | Promise<unknown>)[]
     ) => {
       const kit = await getConnectedKit();
       dispatch('setPendingActionCount', operations.length);
@@ -208,9 +210,9 @@ export interface ContractKitMethods {
   initConnector: (connector: Connector) => Promise<Connector>;
   updateNetwork: (network: Network) => Promise<void>;
   connect: () => Promise<Connector>;
-  getConnectedKit: () => Promise<ContractKit>;
+  getConnectedKit: () => Promise<MiniContractKit>;
   performActions: (
-    ...operations: ((kit: ContractKit) => unknown | Promise<unknown>)[]
+    ...operations: ((kit: MiniContractKit) => unknown | Promise<unknown>)[]
   ) => Promise<unknown[]>;
   updateFeeCurrency: (newFeeCurrency: CeloTokenContract) => Promise<void>;
 }

--- a/packages/use-contractkit/src/use-contract-kit-methods.ts
+++ b/packages/use-contractkit/src/use-contract-kit-methods.ts
@@ -10,6 +10,10 @@ import {
   WalletTypes,
 } from './constants';
 import { Dispatcher } from './contract-kit-provider';
+import {
+  ContractCacheBuilder,
+  useContractsCache,
+} from './ContractCacheBuilder';
 import { Connector, Network } from './types';
 
 export function useContractKitMethods(
@@ -22,7 +26,8 @@ export function useContractKitMethods(
     networks: Network[];
     network: Network;
   },
-  dispatch: Dispatcher
+  dispatch: Dispatcher,
+  buildContractsCache?: ContractCacheBuilder
 ): ContractKitMethods {
   const destroy = useCallback(async () => {
     await connector.close();
@@ -194,6 +199,8 @@ export function useContractKitMethods(
     [getConnectedKit, dispatch, connector]
   );
 
+  const contractsCache = useContractsCache(buildContractsCache, connector);
+
   return {
     destroy,
     initConnector,
@@ -202,6 +209,7 @@ export function useContractKitMethods(
     getConnectedKit,
     performActions,
     updateFeeCurrency,
+    contractsCache,
   };
 }
 
@@ -215,4 +223,5 @@ export interface ContractKitMethods {
     ...operations: ((kit: MiniContractKit) => unknown | Promise<unknown>)[]
   ) => Promise<unknown[]>;
   updateFeeCurrency: (newFeeCurrency: CeloTokenContract) => Promise<void>;
+  contractsCache?: undefined | unknown;
 }

--- a/packages/use-contractkit/src/use-contractkit.tsx
+++ b/packages/use-contractkit/src/use-contractkit.tsx
@@ -1,4 +1,5 @@
-import { CeloTokenContract, ContractKit } from '@celo/contractkit';
+import { CeloTokenContract } from '@celo/contractkit/lib/base';
+import { MiniContractKit } from '@celo/contractkit/lib/mini-kit';
 
 import { WalletTypes } from './constants';
 import { useContractKitContext } from './contract-kit-provider';
@@ -6,7 +7,7 @@ import { Connector, Dapp, Network } from './types';
 
 export interface UseContractKit {
   dapp: Dapp;
-  kit: ContractKit;
+  kit: MiniContractKit;
   walletType: WalletTypes;
   feeCurrency: CeloTokenContract;
 
@@ -29,7 +30,7 @@ export interface UseContractKit {
    * - handle multiple transactions in order
    */
   performActions: (
-    ...operations: ((kit: ContractKit) => unknown | Promise<unknown>)[]
+    ...operations: ((kit: MiniContractKit) => unknown | Promise<unknown>)[]
   ) => Promise<unknown[]>;
 
   /**
@@ -42,10 +43,10 @@ export interface UseContractKit {
   initError: Error | null;
 
   /**
-   * Gets the connected instance of ContractKit.
+   * Gets the connected instance of MiniContractKit.
    * If the user is not connected, this opens up the connection modal.
    */
-  getConnectedKit: () => Promise<ContractKit>;
+  getConnectedKit: () => Promise<MiniContractKit>;
 }
 
 export const useContractKit = (): UseContractKit => {

--- a/packages/use-contractkit/src/use-contractkit.tsx
+++ b/packages/use-contractkit/src/use-contractkit.tsx
@@ -47,9 +47,11 @@ export interface UseContractKit {
    * If the user is not connected, this opens up the connection modal.
    */
   getConnectedKit: () => Promise<MiniContractKit>;
+
+  contractsCache?: unknown;
 }
 
-export const useContractKit = (): UseContractKit => {
+export function useContractKit<CC = undefined>(): UseContractKit {
   const [
     {
       dapp,
@@ -68,6 +70,7 @@ export const useContractKit = (): UseContractKit => {
       getConnectedKit,
       performActions,
       updateFeeCurrency,
+      contractsCache,
     },
   ] = useContractKitContext();
 
@@ -79,6 +82,7 @@ export const useContractKit = (): UseContractKit => {
     networks: networks.map((net) => ({ ...net })),
     updateNetwork,
     kit: connector.kit,
+    contractsCache: contractsCache as CC,
     walletType: connector.type,
     account: connector.account,
     initialised: connector.initialised,
@@ -92,7 +96,7 @@ export const useContractKit = (): UseContractKit => {
 
     initError: connectorInitError,
   };
-};
+}
 
 interface UseContractKitInternal extends UseContractKit {
   connectionCallback: ((connector: Connector | false) => void) | null;

--- a/packages/use-contractkit/src/utils/helpers.ts
+++ b/packages/use-contractkit/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { CeloContract, CeloTokenContract } from '@celo/contractkit';
+import { CeloContract, CeloTokenContract } from '@celo/contractkit/lib/base';
 
 import { CONNECTOR_TYPES, UnauthenticatedConnector } from '../connectors';
 import { localStorageKeys, WalletTypes } from '../constants';

--- a/packages/use-contractkit/src/utils/metamask.ts
+++ b/packages/use-contractkit/src/utils/metamask.ts
@@ -1,4 +1,4 @@
-import { ContractKit, newKit } from '@celo/contractkit';
+import { ContractKit, newKit } from '@celo/contractkit/lib/mini-kit';
 import { GoldTokenWrapper } from '@celo/contractkit/lib/wrappers/GoldTokenWrapper';
 import { StableTokenWrapper } from '@celo/contractkit/lib/wrappers/StableTokenWrapper';
 import Web3 from 'web3';

--- a/packages/use-contractkit/src/utils/metamask.ts
+++ b/packages/use-contractkit/src/utils/metamask.ts
@@ -1,4 +1,4 @@
-import { ContractKit, newKit } from '@celo/contractkit/lib/mini-kit';
+import { MiniContractKit, newKit } from '@celo/contractkit/lib/mini-kit';
 import { GoldTokenWrapper } from '@celo/contractkit/lib/wrappers/GoldTokenWrapper';
 import { StableTokenWrapper } from '@celo/contractkit/lib/wrappers/StableTokenWrapper';
 import Web3 from 'web3';
@@ -210,7 +210,7 @@ export async function addNetworksToMetamask(ethereum: Ethereum): Promise<void> {
 }
 
 export async function switchToCeloNetwork(
-  kit: ContractKit,
+  kit: MiniContractKit,
   network: Network,
   ethereum: Ethereum
 ): Promise<void> {

--- a/packages/wallet-walletconnect/scripts/run-in-memory-client.ts
+++ b/packages/wallet-walletconnect/scripts/run-in-memory-client.ts
@@ -1,4 +1,4 @@
-import { newKit } from '@celo/contractkit';
+import { newKit } from '@celo/contractkit/lib/mini-kit';
 // import {
 //   // ensureLeading0x,
 //   privateKeyToPublicKey,

--- a/packages/wallet-walletconnect/src/test/common.ts
+++ b/packages/wallet-walletconnect/src/test/common.ts
@@ -1,6 +1,6 @@
 import { Address } from '@celo/base';
 import { CeloTx, ReadOnlyWallet } from '@celo/connect';
-import { newKit } from '@celo/contractkit';
+import { newKit } from '@celo/contractkit/lib/mini-kit';
 import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils';
 import { toChecksumAddress } from 'ethereumjs-util';
 
@@ -41,7 +41,7 @@ export function parseDecrypt(params: [string, string]): {
 const privateKey =
   '04f9d516be49bb44346ca040bdd2736d486bca868693c74d51d274ad92f61976';
 const kit = newKit('https://alfajores-forno.celo-testnet.org');
-kit.addAccount(privateKey);
+kit.connection.addAccount(privateKey);
 const wallet = kit.getWallet()!;
 const [account] = wallet.getAccounts();
 

--- a/packages/wallet-walletconnect/src/test/in-memory-wallet.ts
+++ b/packages/wallet-walletconnect/src/test/in-memory-wallet.ts
@@ -1,5 +1,5 @@
 import { CeloTx, EncodedTransaction } from '@celo/connect';
-import { newKit } from '@celo/contractkit';
+import { newKit } from '@celo/contractkit/lib/mini-kit';
 import { toChecksumAddress } from '@celo/utils/lib/address';
 import WalletConnect, { CLIENT_EVENTS } from '@walletconnect/client';
 import {
@@ -24,7 +24,7 @@ const debug = debugConfig('in-memory-wallet');
 const privateKey =
   '04f9d516be49bb44346ca040bdd2736d486bca868693c74d51d274ad92f61976';
 const kit = newKit('https://alfajores-forno.celo-testnet.org');
-kit.addAccount(privateKey);
+kit.connection.addAccount(privateKey);
 const wallet = kit.getWallet()!;
 const [account] = wallet.getAccounts();
 

--- a/packages/walletconnect-v1/__tests__/utils/common.ts
+++ b/packages/walletconnect-v1/__tests__/utils/common.ts
@@ -1,6 +1,6 @@
 import { Address } from '@celo/base';
 import { CeloTx } from '@celo/connect';
-import { newKit } from '@celo/contractkit';
+import { newKit } from '@celo/contractkit/lib/mini-kit';
 import { EIP712TypedData } from '@celo/utils/lib/sign-typed-data-utils';
 import { toChecksumAddress } from 'ethereumjs-util';
 
@@ -41,7 +41,7 @@ export function parseDecrypt(params: [string, string]): {
 const privateKey =
   '04f9d516be49bb44346ca040bdd2736d486bca868693c74d51d274ad92f61976';
 const kit = newKit('https://alfajores-forno.celo-testnet.org');
-kit.addAccount(privateKey);
+kit.connection.addAccount(privateKey);
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const wallet = kit.getWallet()!;
 const [account] = wallet.getAccounts();

--- a/packages/walletconnect-v1/__tests__/utils/in-memory-wallet.ts
+++ b/packages/walletconnect-v1/__tests__/utils/in-memory-wallet.ts
@@ -1,6 +1,6 @@
 /// <reference path='../../../../node_modules/@walletconnect/types-v1/index.d.ts' />
 
-import { newKit } from '@celo/contractkit';
+import { newKit } from '@celo/contractkit/lib/mini-kit';
 import { toChecksumAddress } from '@celo/utils/lib/address';
 import WalletConnect from '@walletconnect/client-v1';
 import { IInternalEvent } from '@walletconnect/types';
@@ -26,8 +26,7 @@ const debug = debugConfig('in-memory-wallet');
 const privateKey =
   '04f9d516be49bb44346ca040bdd2736d486bca868693c74d51d274ad92f61976';
 const kit = newKit('https://alfajores-forno.celo-testnet.org');
-kit.addAccount(privateKey);
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+kit.connection.addAccount(privateKey);
 const wallet = kit.getWallet()!;
 const [account] = wallet.getAccounts();
 


### PR DESCRIPTION
## What: 

Rather than `useContractKit().kit` return a full contractKit instance it now will give back a MiniContractKit which has a subset of the features. 

## Why:

Bringing in the Full ContractKit means the Contract Classes, Wrappers, and JSON ABIs for every core Celo Contract are loaded into the dapp. For most dapps this is extra weight that provides no benefit. MiniContractKit only includes a couple of Contracts thus bundle size is dramatically reduced. 


### size comparison based on node modules of example app

#### using Minikit

![Screen Shot 2022-05-11 at 1 26 31 PM](https://user-images.githubusercontent.com/3814795/167943168-3df492dd-d62a-4996-aa03-040e7d270fc9.png)

#### using Full Contract Kit
![Screen Shot 2022-05-11 at 1 28 36 PM](https://user-images.githubusercontent.com/3814795/167943171-e6d0ac12-c874-491d-a714-95f102b30398.png)



## Comptability: 
For developers that want close to the old behavior a new option has been added to ContractKitProvider, `buildContractsCache`.  providing this with a function that returns a Wrapper Cache and then access it like `const {contactsCache} =useContractKit()`