### PR TITLE
Fix StableTokenBRL error: Catch token not registered error, display non-deployed token in balances

### DIFF
--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -16,7 +16,7 @@ interface Summary {
   address: string;
   wallet: string;
   celo: BigNumber;
-  balances: { symbol: StableToken; value: BigNumber | string }[];
+  balances: { symbol: StableToken; value: string }[];
 }
 
 const defaultSummary: Summary = {
@@ -385,10 +385,7 @@ export default function Home(): React.ReactElement {
                     </div>
                     {summary.balances.map((token) => (
                       <div key={token.symbol}>
-                        {token.symbol}:{' '}
-                        {typeof token.value == 'string'
-                          ? token.value
-                          : Web3.utils.fromWei(token.value.toFixed())}
+                        {token.symbol}: {token.value}
                       </div>
                     ))}
                   </div>
@@ -426,11 +423,18 @@ async function getBalances(
   address: string
 ) {
   return Promise.all(
-    stableTokens.map(async (stable) => ({
-      symbol: stable.symbol,
-      value: stable.contract
-        ? await stable.contract.balanceOf(address)
-        : `not deployed in network`,
-    }))
+    stableTokens.map(async (stable) => {
+      let value;
+      if (stable.contract) {
+        const balance = await stable.contract.balanceOf(address);
+        value = Web3.utils.fromWei(balance.toFixed());
+      } else {
+        value = 'not deployed in network';
+      }
+      return {
+        symbol: stable.symbol,
+        value: value,
+      };
+    })
   );
 }

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -70,10 +70,12 @@ export default function Home(): React.ReactElement {
       kit.contracts.getGoldToken(),
       Promise.all(
         Object.values(StableToken).map(async (stable) => {
-          let contract = null;
+          let contract;
           try {
             contract = await kit.contracts.getStableToken(stable);
-          } catch (e) {}
+          } catch (e) {
+            contract = null;
+          }
           return {
             symbol: stable,
             contract: contract,

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -16,7 +16,7 @@ interface Summary {
   address: string;
   wallet: string;
   celo: BigNumber;
-  balances: { symbol: StableToken; value: string }[];
+  balances: { symbol: StableToken; value?: BigNumber; error?: string }[];
 }
 
 const defaultSummary: Summary = {
@@ -386,7 +386,10 @@ export default function Home(): React.ReactElement {
                     </div>
                     {summary.balances.map((token) => (
                       <div key={token.symbol}>
-                        {token.symbol}: {token.value}
+                        {token.symbol}:{' '}
+                        {token.value
+                          ? Web3.utils.fromWei(token.value.toFixed())
+                          : token.error}
                       </div>
                     ))}
                   </div>
@@ -425,16 +428,16 @@ async function getBalances(
 ) {
   return Promise.all(
     stableTokens.map(async (stable) => {
-      let value;
+      let value, error;
       if (stable.contract) {
-        const balance = await stable.contract.balanceOf(address);
-        value = Web3.utils.fromWei(balance.toFixed());
+        value = await stable.contract.balanceOf(address);
       } else {
-        value = 'not deployed in network';
+        error = 'not deployed in network';
       }
       return {
         symbol: stable.symbol,
         value: value,
+        error: error,
       };
     })
   );

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -75,6 +75,7 @@ export default function Home(): React.ReactElement {
             contract = await kit.contracts.getStableToken(stable);
           } catch (e) {
             contract = null;
+            console.error(e);
           }
           return {
             symbol: stable,


### PR DESCRIPTION
Fix #146 #178

StableTokenBRL not currently deployed to Baklava, and was receiving `Error: StableTokenBRL not (yet) registered` on the sample app. This change catches the UnregisteredError and shows "not deployed in network" under the token balances.