### PR TITLE
Connector Testing 

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "eslint-plugin-unused-imports": "^2.0.0",
+    "eth-testing": "^1.0.0",
     "husky": "^7.0.4",
     "jest": "^28.1.0",
     "lerna": "^4.0.0",

--- a/packages/react-celo/__tests__/connectors/ledger.test.ts
+++ b/packages/react-celo/__tests__/connectors/ledger.test.ts
@@ -1,0 +1,58 @@
+import { CeloContract } from '@celo/contractkit';
+
+import { Alfajores, localStorageKeys, WalletTypes } from '../../src';
+import { LedgerConnector } from '../../src/connectors';
+
+describe('LedgerConnector', () => {
+  let connector: LedgerConnector;
+  beforeEach(() => {
+    connector = new LedgerConnector(Alfajores, 0, CeloContract.GoldToken);
+  });
+
+  it('remembers info in localStorage', () => {
+    expect(localStorage.getItem(localStorageKeys.lastUsedFeeCurrency)).toEqual(
+      null
+    );
+
+    expect(localStorage.getItem(localStorageKeys.lastUsedWalletType)).toEqual(
+      WalletTypes.Ledger
+    );
+
+    expect(
+      localStorage.getItem(localStorageKeys.lastUsedWalletArguments)
+    ).toEqual('[0]');
+
+    expect(localStorage.getItem(localStorageKeys.lastUsedNetwork)).toEqual(
+      'Alfajores'
+    );
+  });
+
+  describe('close()', () => {
+    it('clears out localStorage', () => {
+      connector.close();
+
+      expect(
+        localStorage.getItem(localStorageKeys.lastUsedFeeCurrency)
+      ).toEqual(null);
+
+      expect(
+        localStorage.getItem(localStorageKeys.lastUsedWalletArguments)
+      ).toEqual(null);
+
+      expect(localStorage.getItem(localStorageKeys.lastUsedNetwork)).toEqual(
+        null
+      );
+    });
+  });
+  describe('updateFeeCurrency', () => {
+    it('sets fee currency and in fact uses it', async () => {
+      await connector.updateFeeCurrency(CeloContract.StableToken);
+
+      expect(connector.feeCurrency).toEqual(CeloContract.StableToken);
+
+      expect(connector.kit.connection.defaultFeeCurrency).toEqual(
+        '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1'
+      );
+    });
+  });
+});

--- a/packages/react-celo/__tests__/connectors/metamask.test.ts
+++ b/packages/react-celo/__tests__/connectors/metamask.test.ts
@@ -11,7 +11,7 @@ const ACCOUNT = '0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf';
 describe('MetaMaskConnector', () => {
   const testingUtils = generateTestingUtils({
     providerType: 'MetaMask',
-    verbose: true,
+    verbose: false,
   });
   beforeAll(() => {
     // Manually inject the mocked provider in the window as MetaMask does

--- a/packages/react-celo/__tests__/connectors/metamask.test.ts
+++ b/packages/react-celo/__tests__/connectors/metamask.test.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { CeloContract } from '@celo/contractkit/lib/base';
+import { generateTestingUtils } from 'eth-testing';
+
+import { MetaMaskConnector } from '../../src/connectors';
+import { Alfajores, Baklava, localStorageKeys } from '../../src/constants';
+import localStorage from '../../src/utils/localStorage';
+
+const ACCOUNT = '0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf';
+
+describe('MetaMaskConnector', () => {
+  const testingUtils = generateTestingUtils({
+    providerType: 'MetaMask',
+    verbose: true,
+  });
+  beforeAll(() => {
+    // Manually inject the mocked provider in the window as MetaMask does
+    // @ts-ignore
+    global.window.ethereum = testingUtils.getProvider();
+    testingUtils.mockNotConnectedWallet();
+    testingUtils.mockAccounts([ACCOUNT]);
+    testingUtils.mockRequestAccounts([ACCOUNT]);
+    testingUtils.lowLevel.mockRequest('wallet_switchEthereumChain', {});
+  });
+  afterEach(() => {
+    // Clear all mocks between tests
+    testingUtils.clearAllMocks();
+  });
+
+  it('initialises', async () => {
+    const connector = new MetaMaskConnector(Alfajores, CeloContract.GoldToken);
+    await connector.initialise();
+    expect(connector.account).toEqual(ACCOUNT);
+    expect(connector.initialised).toBe(true);
+  });
+  describe('when network change', () => {
+    let connector: MetaMaskConnector;
+    beforeEach(() => {
+      testingUtils.mockConnectedWallet([ACCOUNT]);
+      connector = new MetaMaskConnector(Alfajores, CeloContract.GoldToken);
+    });
+    it('sets network in local storage and in connection', async () => {
+      await connector.updateKitWithNetwork(Baklava);
+
+      expect(localStorage.getItem(localStorageKeys.lastUsedNetwork)).toEqual(
+        Baklava.name
+      );
+    });
+
+    const callback = jest.fn(console.log);
+
+    it('reacts to network being changed from metamask side', async () => {
+      connector.onNetworkChange(callback);
+
+      // Seems to only work when  init is called after the callback is set
+      await connector.initialise();
+
+      testingUtils.mockChainChanged('0x1');
+
+      expect(callback).toHaveBeenLastCalledWith(1);
+    });
+  });
+});

--- a/packages/react-celo/__tests__/connectors/metamask.test.ts
+++ b/packages/react-celo/__tests__/connectors/metamask.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import { CeloContract } from '@celo/contractkit/lib/base';
 import { generateTestingUtils } from 'eth-testing';
 
@@ -15,6 +14,7 @@ describe('MetaMaskConnector', () => {
   });
   beforeAll(() => {
     // Manually inject the mocked provider in the window as MetaMask does
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     global.window.ethereum = testingUtils.getProvider();
     testingUtils.mockNotConnectedWallet();
@@ -47,7 +47,7 @@ describe('MetaMaskConnector', () => {
       );
     });
 
-    const callback = jest.fn(console.log);
+    const callback = jest.fn();
 
     it('reacts to network being changed from metamask side', async () => {
       connector.onNetworkChange(callback);

--- a/packages/react-celo/__tests__/connectors/private-key.test.ts
+++ b/packages/react-celo/__tests__/connectors/private-key.test.ts
@@ -1,0 +1,81 @@
+import { CeloContract } from '@celo/contractkit';
+
+import { Alfajores, localStorageKeys } from '../../src';
+import { PrivateKeyConnector } from '../../src/connectors';
+
+const TEST_KEY =
+  '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abbdef';
+
+describe('PrivateKeyConnector', () => {
+  let connector: PrivateKeyConnector;
+  describe('initialise()', () => {
+    beforeEach(() => {
+      connector = new PrivateKeyConnector(
+        Alfajores,
+        TEST_KEY,
+        CeloContract.StableTokenEUR
+      );
+    });
+    it('sets the account', async () => {
+      await connector.initialise();
+
+      expect(connector.account).toEqual(
+        '0x6df18c5837718a83581ead5e26bfcdb8a548e409'
+      );
+    });
+
+    it('sets and uses the fee currency', async () => {
+      await connector.initialise();
+
+      expect(connector.feeCurrency).toEqual(CeloContract.StableTokenEUR);
+    });
+
+    it('sets the private key in locale storage', () => {
+      expect(
+        localStorage.getItem(localStorageKeys.lastUsedWalletArguments)
+      ).toEqual(JSON.stringify([TEST_KEY]));
+    });
+
+    it('sets the last network in local storage', () => {
+      expect(localStorage.getItem(localStorageKeys.lastUsedNetwork)).toEqual(
+        Alfajores.name
+      );
+    });
+  });
+
+  describe('close()', () => {
+    it('clears out localStorage', async () => {
+      connector = new PrivateKeyConnector(
+        Alfajores,
+        TEST_KEY,
+        CeloContract.StableTokenEUR
+      );
+      await connector.initialise();
+
+      connector.close();
+
+      expect(
+        localStorage.getItem(localStorageKeys.lastUsedFeeCurrency)
+      ).toEqual(null);
+
+      expect(
+        localStorage.getItem(localStorageKeys.lastUsedWalletArguments)
+      ).toEqual(null);
+
+      expect(localStorage.getItem(localStorageKeys.lastUsedNetwork)).toEqual(
+        null
+      );
+    });
+  });
+  describe('updateFeeCurrency', () => {
+    it('sets fee currency and in fact uses it', async () => {
+      await connector.updateFeeCurrency(CeloContract.StableToken);
+
+      expect(connector.feeCurrency).toEqual(CeloContract.StableToken);
+
+      expect(connector.kit.connection.defaultFeeCurrency).toEqual(
+        '0x874069Fa1Eb16D44d622F2e0Ca25eeA172369bC1'
+      );
+    });
+  });
+});

--- a/packages/react-celo/__tests__/connectors/walletconnect.test.ts
+++ b/packages/react-celo/__tests__/connectors/walletconnect.test.ts
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { CeloContract } from '@celo/contractkit';
+import { WalletConnectWallet } from '@celo/wallet-walletconnect-v1';
+import { generateTestingUtils } from 'eth-testing';
+
+import { Alfajores } from '../../src';
+import { WalletConnectConnector } from '../../src/connectors';
+
+const ACCOUNT = '0xf61B443A155b07D2b2cAeA2d99715dC84E839EEf';
+
+jest.createMockFromModule('@celo/wallet-walletconnect-v1');
+
+const wallet = new WalletConnectWallet({});
+
+jest.spyOn(wallet, 'init').mockImplementation(async function init() {
+  return Promise.resolve(undefined);
+});
+
+jest.spyOn(wallet, 'getAccounts').mockImplementation(function getAccounts() {
+  return [ACCOUNT];
+});
+
+describe('WalletConnectConnector', () => {
+  const testingUtils = generateTestingUtils({
+    providerType: 'WalletConnect',
+    verbose: false,
+  });
+  beforeAll(() => {
+    testingUtils.getProvider();
+    testingUtils.mockNotConnectedWallet();
+    testingUtils.mockAccounts([ACCOUNT]);
+    testingUtils.mockRequestAccounts([ACCOUNT]);
+    testingUtils.lowLevel.mockRequest('wallet_switchEthereumChain', {});
+    jest.setTimeout(11_000);
+  });
+  afterEach(() => {
+    // Clear all mocks between tests
+    testingUtils.clearAllMocks();
+  });
+
+  it('initialises', async () => {
+    const connector = new WalletConnectConnector(
+      Alfajores,
+      CeloContract.GoldToken,
+      { connect: { chainId: Alfajores.chainId } }
+    );
+
+    jest.spyOn(connector.kit, 'getWallet').mockImplementation(() => wallet);
+
+    await connector.initialise();
+    expect(connector.account).toEqual(ACCOUNT);
+    expect(connector.initialised).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(wallet.init).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(wallet.getAccounts).toHaveBeenCalled();
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(connector.kit.getWallet).toHaveBeenCalled();
+  });
+});

--- a/packages/react-celo/__tests__/react-celo-provider.tsx
+++ b/packages/react-celo/__tests__/react-celo-provider.tsx
@@ -1,8 +1,14 @@
 import '@testing-library/jest-dom';
 
-import { renderHook } from '@testing-library/react';
-import React from 'react';
-import { act } from 'react-dom/test-utils';
+import { CeloContract } from '@celo/contractkit';
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  waitFor,
+} from '@testing-library/react';
+import React, { ReactElement } from 'react';
 
 import { Mainnet } from '../src/constants';
 import { CeloProvider, CeloProviderProps } from '../src/react-celo-provider';
@@ -23,7 +29,7 @@ const defaultProps: CeloProviderProps = {
   children: null,
 };
 
-function customRender<R>(
+function renderHookInCKProvider<R>(
   hook: (i: unknown) => R,
   { providerProps }: RenderArgs
 ) {
@@ -35,63 +41,160 @@ function customRender<R>(
   });
 }
 
-describe('CeloProvider', () => {
-  describe('with networks', () => {
-    const networks: Network[] = [
-      {
-        name: 'SecureFastChain',
-        rpcUrl: 'https://rpc-mainnet.matic.network',
-        explorer: 'https://explorer.example.com',
-        chainId: 9812374,
-        nativeCurrency: {
-          name: 'SFC',
-          symbol: 'SFC',
-          decimals: 18,
-        },
-      },
-      {
-        name: 'BoringChain',
-        rpcUrl: 'https://bsc-dataseed.binance.org/',
-        explorer: 'https://explorer.boringchain.org',
-        chainId: 0x38,
-        nativeCurrency: {
-          name: 'BORING',
-          symbol: 'BOR',
-          decimals: 18,
-        },
-      },
-    ];
+function renderComponentInCKProvider(
+  ui: ReactElement<any, string>,
+  { providerProps }: RenderArgs
+) {
+  return render(ui, {
+    wrapper: ({ children }) => {
+      const props = { ...defaultProps, ...providerProps };
+      return <CeloProvider {...props}>{children}</CeloProvider>;
+    },
+  });
+}
 
+describe('CeloProvider', () => {
+  describe('user interface', () => {
+    const ConnectButton = () => {
+      const { connect } = useCelo();
+      return <button onClick={connect}>Connect</button>;
+    };
+
+    async function stepsToOpenModal() {
+      const dom = renderComponentInCKProvider(<ConnectButton />, {
+        providerProps: {},
+      });
+
+      const button = await dom.findByText('Connect');
+      act(() => {
+        fireEvent.click(button);
+      });
+
+      return dom;
+    }
+
+    describe('when Button with connect is Pressed', () => {
+      it('opens wallets modal', async () => {
+        const dom = await stepsToOpenModal();
+
+        const modal = await dom.findByText('Connect a wallet');
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+        expect(modal).toBeVisible();
+      });
+    });
+
+    describe('when a wallet is selected', () => {
+      it.skip('changes to the screen for that wallet', async () => {
+        const dom = await stepsToOpenModal();
+        const celoWalletButton = await dom.findByText('Celo Wallet');
+        await waitFor(
+          () => {
+            fireEvent.click(celoWalletButton);
+          },
+          {
+            timeout: 5,
+          }
+        );
+
+        dom.debug();
+      });
+    });
+  });
+
+  describe('hook interface', () => {
     const renderUseCK = (props: Partial<CeloProviderProps>) =>
-      customRender<UseCelo>(useCelo, {
+      renderHookInCKProvider<UseCelo>(useCelo, {
         providerProps: props,
       });
 
-    it('defaults to Celo Mainnet', () => {
-      const hookReturn = renderUseCK({});
-      expect(hookReturn.result.current.network).toEqual(Mainnet);
-    });
+    describe('regarding networks', () => {
+      const networks: Network[] = [
+        {
+          name: 'SecureFastChain',
+          rpcUrl: 'https://rpc-mainnet.matic.network',
+          explorer: 'https://explorer.example.com',
+          chainId: 9812374,
+          nativeCurrency: {
+            name: 'SFC',
+            symbol: 'SFC',
+            decimals: 18,
+          },
+        },
+        {
+          name: 'BoringChain',
+          rpcUrl: 'https://bsc-dataseed.binance.org/',
+          explorer: 'https://explorer.boringchain.org',
+          chainId: 0x38,
+          nativeCurrency: {
+            name: 'BORING',
+            symbol: 'BOR',
+            decimals: 18,
+          },
+        },
+      ];
 
-    it('supports passing other networks', () => {
-      const hookReturn = renderUseCK({ networks, network: networks[0] });
-      expect(hookReturn.result.current.networks).toEqual(networks);
-
-      expect(hookReturn.result.current.network).toEqual(networks[0]);
-    });
-
-    it('updates the Current network', async () => {
-      const { result, rerender } = renderUseCK({ networks });
-
-      // FIXME Need to determine behavior when network is not in networks
-      expect(result.current.network).toEqual(Mainnet);
-
-      await act(async () => {
-        await result.current.updateNetwork(networks[1]);
+      it('defaults to Celo Mainnet', () => {
+        const hookReturn = renderUseCK({});
+        expect(hookReturn.result.current.network).toEqual(Mainnet);
       });
 
-      rerender();
+      it('supports passing other networks', () => {
+        const hookReturn = renderUseCK({ networks, network: networks[0] });
+        expect(hookReturn.result.current.networks).toEqual(networks);
 
-      expect(result.current.network).toEqual(networks[1]);
+        expect(hookReturn.result.current.network).toEqual(networks[0]);
+      });
+
+      it('updates the Current network', async () => {
+        const { result, rerender } = renderUseCK({ networks });
+
+        // FIXME Need to determine behavior when network is not in networks
+        expect(result.current.network).toEqual(Mainnet);
+
+        await act(async () => {
+          await result.current.updateNetwork(networks[1]);
+        });
+
+        rerender();
+
+        expect(result.current.network).toEqual(networks[1]);
+      });
+    });
+
+    describe('regarding feeCurrency', () => {
+      describe('when none given', () => {
+        it('defaults to CELO', () => {
+          const { result } = renderUseCK({});
+          expect(result.current.feeCurrency).toEqual(CeloContract.GoldToken);
+        });
+        it('does not set on the kit as connector is Unauthenticated', () => {
+          const { result } = renderUseCK({});
+          expect(result.current.walletType).toEqual('Unauthenticated');
+          expect(result.current.kit.connection.defaultFeeCurrency).toEqual(
+            undefined
+          );
+        });
+      });
+
+      describe('when feeCurrency WhitelistToken passed', () => {
+        it('sets that as the feeCurrency', () => {
+          const { result } = renderUseCK({
+            feeCurrency: CeloContract.StableTokenBRL,
+          });
+
+          expect(result.current.feeCurrency).toEqual(
+            CeloContract.StableTokenBRL
+          );
+        });
+
+        it.todo('sets on the kit');
+
+        it('allows updating feeCurrency', () => {
+          const { result } = renderUseCK({});
+
+          expect(result.current.supportsFeeCurrency).toBe(false);
+        });
+      });
     });
   });
 });

--- a/packages/react-celo/__tests__/react-celo-provider.tsx
+++ b/packages/react-celo/__tests__/react-celo-provider.tsx
@@ -1,13 +1,7 @@
 import '@testing-library/jest-dom';
 
 import { CeloContract } from '@celo/contractkit';
-import {
-  act,
-  fireEvent,
-  render,
-  renderHook,
-  waitFor,
-} from '@testing-library/react';
+import { act, fireEvent, render, renderHook } from '@testing-library/react';
 import React, { ReactElement } from 'react';
 
 import { Mainnet } from '../src/constants';
@@ -42,7 +36,7 @@ function renderHookInCKProvider<R>(
 }
 
 function renderComponentInCKProvider(
-  ui: ReactElement<any, string>,
+  ui: ReactElement<unknown, string>,
   { providerProps }: RenderArgs
 ) {
   return render(ui, {
@@ -82,23 +76,6 @@ describe('CeloProvider', () => {
         expect(modal).toBeVisible();
       });
     });
-
-    describe('when a wallet is selected', () => {
-      it.skip('changes to the screen for that wallet', async () => {
-        const dom = await stepsToOpenModal();
-        const celoWalletButton = await dom.findByText('Celo Wallet');
-        await waitFor(
-          () => {
-            fireEvent.click(celoWalletButton);
-          },
-          {
-            timeout: 5,
-          }
-        );
-
-        dom.debug();
-      });
-    });
   });
 
   describe('hook interface', () => {
@@ -136,6 +113,7 @@ describe('CeloProvider', () => {
       it('defaults to Celo Mainnet', () => {
         const hookReturn = renderUseCK({});
         expect(hookReturn.result.current.network).toEqual(Mainnet);
+        hookReturn.unmount();
       });
 
       it('supports passing other networks', () => {
@@ -143,10 +121,11 @@ describe('CeloProvider', () => {
         expect(hookReturn.result.current.networks).toEqual(networks);
 
         expect(hookReturn.result.current.network).toEqual(networks[0]);
+        hookReturn.unmount();
       });
 
       it('updates the Current network', async () => {
-        const { result, rerender } = renderUseCK({ networks });
+        const { result, rerender, unmount } = renderUseCK({ networks });
 
         // FIXME Need to determine behavior when network is not in networks
         expect(result.current.network).toEqual(Mainnet);
@@ -158,21 +137,24 @@ describe('CeloProvider', () => {
         rerender();
 
         expect(result.current.network).toEqual(networks[1]);
+        unmount();
       });
     });
 
     describe('regarding feeCurrency', () => {
       describe('when none given', () => {
         it('defaults to CELO', () => {
-          const { result } = renderUseCK({});
+          const { result, unmount } = renderUseCK({});
           expect(result.current.feeCurrency).toEqual(CeloContract.GoldToken);
+          unmount();
         });
         it('does not set on the kit as connector is Unauthenticated', () => {
-          const { result } = renderUseCK({});
+          const { result, unmount } = renderUseCK({});
           expect(result.current.walletType).toEqual('Unauthenticated');
           expect(result.current.kit.connection.defaultFeeCurrency).toEqual(
             undefined
           );
+          unmount();
         });
       });
 

--- a/packages/react-celo/__tests__/react-celo-provider.tsx
+++ b/packages/react-celo/__tests__/react-celo-provider.tsx
@@ -127,7 +127,7 @@ describe('CeloProvider', () => {
       it('updates the Current network', async () => {
         const { result, rerender, unmount } = renderUseCK({ networks });
 
-        // FIXME Need to determine behavior when network is not in networks
+        // TODO Need to determine behavior when network is not in networks
         expect(result.current.network).toEqual(Mainnet);
 
         await act(async () => {
@@ -148,7 +148,7 @@ describe('CeloProvider', () => {
           expect(result.current.feeCurrency).toEqual(CeloContract.GoldToken);
           unmount();
         });
-        it('does not set on the kit as connector is Unauthenticated', () => {
+        it('does not set any feeCurrency on the kit', () => {
           const { result, unmount } = renderUseCK({});
           expect(result.current.walletType).toEqual('Unauthenticated');
           expect(result.current.kit.connection.defaultFeeCurrency).toEqual(

--- a/packages/react-celo/src/connectors/connectors.ts
+++ b/packages/react-celo/src/connectors/connectors.ts
@@ -259,6 +259,7 @@ export class InjectedConnector implements Connector {
 
   async updateKitWithNetwork(network: Network): Promise<void> {
     localStorage.setItem(localStorageKeys.lastUsedNetwork, network.name);
+    this.network = network;
     await this.initialise();
   }
 

--- a/packages/react-celo/src/connectors/connectors.ts
+++ b/packages/react-celo/src/connectors/connectors.ts
@@ -185,7 +185,7 @@ export class UnsupportedChainIdError extends Error {
 
 export class InjectedConnector implements Connector {
   public initialised = false;
-  public type = WalletTypes.CeloExtensionWallet;
+  public type = WalletTypes.Injected;
   public kit: MiniContractKit;
   public account: Maybe<string> = null;
   private onNetworkChangeCallback?: (chainId: number) => void;
@@ -218,7 +218,9 @@ export class InjectedConnector implements Connector {
 
     this.type = isMetaMask ? WalletTypes.MetaMask : WalletTypes.Injected;
 
-    void (await ethereum.request({ method: 'eth_requestAccounts' }));
+    const [defaultAccount] = await ethereum.request({
+      method: 'eth_requestAccounts',
+    });
 
     ethereum.removeListener('chainChanged', this.onChainChanged);
     ethereum.removeListener('accountsChanged', this.onAccountsChanged);
@@ -227,7 +229,7 @@ export class InjectedConnector implements Connector {
     ethereum.on('accountsChanged', this.onAccountsChanged);
 
     this.kit = newKitFromWeb3(web3 as unknown as Web3Type);
-    const [defaultAccount] = await this.kit.connection.web3.eth.getAccounts();
+
     this.kit.connection.defaultAccount = defaultAccount;
     this.account = defaultAccount ?? null;
     this.initialised = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -688,6 +688,34 @@
     "@ethersproject/properties" "^5.0.3"
     "@ethersproject/strings" "^5.0.4"
 
+"@ethersproject/abi@5.6.1", "@ethersproject/abi@^5.6.0":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.6.1.tgz#f7de888edeb56b0a657b672bdd1b3a1135cd14f7"
+  integrity sha512-0cqssYh6FXjlwKWBmLm3+zH2BNARoS5u/hxbz+LpQmcDB3w0W553h2btWui1/uZp2GBM/SI3KniTuMcYyHpA5w==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
+"@ethersproject/abstract-provider@5.6.0", "@ethersproject/abstract-provider@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.6.0.tgz#0c4ac7054650dbd9c476cf5907f588bbb6ef3061"
+  integrity sha512-oPMFlKLN+g+y7a79cLK3WiLcjWFnZQtXWgnLAbHZcN3s7L4v90UHpTOrLk+m3yr0gt+/h9STTM6zrr7PM8uoRw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/web" "^5.6.0"
+
 "@ethersproject/abstract-provider@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz#e404309a29f771bd4d28dbafadcaa184668c2a6e"
@@ -714,6 +742,17 @@
     "@ethersproject/transactions" "^5.5.0"
     "@ethersproject/web" "^5.5.0"
 
+"@ethersproject/abstract-signer@5.6.0", "@ethersproject/abstract-signer@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz#9cd7ae9211c2b123a3b29bf47aab17d4d016e3e7"
+  integrity sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+
 "@ethersproject/abstract-signer@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.4.1.tgz#e4e9abcf4dd4f1ba0db7dff9746a5f78f355ea81"
@@ -735,6 +774,17 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
+
+"@ethersproject/address@5.6.0", "@ethersproject/address@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.6.0.tgz#13c49836d73e7885fc148ad633afad729da25012"
+  integrity sha512-6nvhYXjbXsHPS+30sHZ+U4VMagFC/9zAk6Gd/h3S21YW4+yfb0WfRtaAIZ4kfM4rrVwqiy284LP0GtL5HXGLxQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
 
 "@ethersproject/address@^5.0.4", "@ethersproject/address@^5.4.0":
   version "5.4.0"
@@ -758,6 +808,13 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/rlp" "^5.5.0"
 
+"@ethersproject/base64@5.6.0", "@ethersproject/base64@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.6.0.tgz#a12c4da2a6fb86d88563216b0282308fc15907c9"
+  integrity sha512-2Neq8wxJ9xHxCF9TUgmKeSh9BXJ6OAxWfeGWvbauPh8FuHEjamgHilllx8KkSd5ErxyHIX7Xv3Fkcud2kY9ezw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+
 "@ethersproject/base64@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.4.0.tgz#7252bf65295954c9048c7ca5f43e5c86441b2a9a"
@@ -772,6 +829,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
 
+"@ethersproject/basex@5.6.0", "@ethersproject/basex@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.6.0.tgz#9ea7209bf0a1c3ddc2a90f180c3a7f0d7d2e8a69"
+  integrity sha512-qN4T+hQd/Md32MoJpc69rOwLYRUXwjTlhHDIeUkUmiN/JyWkkLLMoG0TqvSQKNqZOMgN5stbUYN6ILC+eD7MEQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+
 "@ethersproject/basex@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.5.0.tgz#e40a53ae6d6b09ab4d977bd037010d4bed21b4d3"
@@ -779,6 +844,15 @@
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
+
+"@ethersproject/bignumber@5.6.0", "@ethersproject/bignumber@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.6.0.tgz#116c81b075c57fa765a8f3822648cf718a8a0e26"
+  integrity sha512-VziMaXIUHQlHJmkv1dlcd6GY2PmT0khtAqaMctCIDogxkrarMzA9L94KN1NeXqqOfFD6r0sJT3vCTOFSmZ07DA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    bn.js "^4.11.9"
 
 "@ethersproject/bignumber@^5.0.7", "@ethersproject/bignumber@^5.4.0":
   version "5.4.1"
@@ -798,6 +872,13 @@
     "@ethersproject/logger" "^5.5.0"
     bn.js "^4.11.9"
 
+"@ethersproject/bytes@5.6.1", "@ethersproject/bytes@^5.6.0":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.1.tgz#24f916e411f82a8a60412344bf4a813b917eefe7"
+  integrity sha512-NwQt7cKn5+ZE4uDn+X5RAXLp46E1chXoaMmrxAyA0rblpxz8t58lVkrHXoRIn0lz1joQElQ8410GqhTqMOwc6g==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/bytes@^5.0.4", "@ethersproject/bytes@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.4.0.tgz#56fa32ce3bf67153756dbaefda921d1d4774404e"
@@ -812,6 +893,13 @@
   dependencies:
     "@ethersproject/logger" "^5.5.0"
 
+"@ethersproject/constants@5.6.0", "@ethersproject/constants@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.6.0.tgz#55e3eb0918584d3acc0688e9958b0cedef297088"
+  integrity sha512-SrdaJx2bK0WQl23nSpV/b1aq293Lh0sUaZT/yYKPDKn4tlAbkH96SPJwIhwSwTsoQQZxuh1jnqsKwyymoiBdWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+
 "@ethersproject/constants@^5.0.4", "@ethersproject/constants@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.4.0.tgz#ee0bdcb30bf1b532d2353c977bf2ef1ee117958a"
@@ -825,6 +913,36 @@
   integrity sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==
   dependencies:
     "@ethersproject/bignumber" "^5.5.0"
+
+"@ethersproject/contracts@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.6.0.tgz#60f2cfc7addd99a865c6c8cfbbcec76297386067"
+  integrity sha512-74Ge7iqTDom0NX+mux8KbRUeJgu1eHZ3iv6utv++sLJG80FVuU9HnHeKVPfjd9s3woFhaFoQGf3B3iH/FrQmgw==
+  dependencies:
+    "@ethersproject/abi" "^5.6.0"
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+
+"@ethersproject/hash@5.6.0", "@ethersproject/hash@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.6.0.tgz#d24446a5263e02492f9808baa99b6e2b4c3429a2"
+  integrity sha512-fFd+k9gtczqlr0/BruWLAu7UAOas1uRRJvOR84uDf4lNZ+bTkGl366qvniUZHKtlqxBRU65MkOobkmvmpHU+jA==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
 
 "@ethersproject/hash@^5.0.4":
   version "5.4.0"
@@ -854,6 +972,51 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
+"@ethersproject/hdnode@5.6.0", "@ethersproject/hdnode@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.6.0.tgz#9dcbe8d629bbbcf144f2cae476337fe92d320998"
+  integrity sha512-61g3Jp3nwDqJcL/p4nugSyLrpl/+ChXIOtCEM8UDmWeB3JCAt5FoLdOMXQc3WWkc0oM2C0aAn6GFqqMcS/mHTw==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/basex" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/pbkdf2" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/wordlists" "^5.6.0"
+
+"@ethersproject/json-wallets@5.6.0", "@ethersproject/json-wallets@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.6.0.tgz#4c2fc27f17e36c583e7a252fb938bc46f98891e5"
+  integrity sha512-fmh86jViB9r0ibWXTQipxpAGMiuxoqUf78oqJDlCAJXgnJF024hOOX7qVgqsjtbeoxmcLwpPsXNU0WEe/16qPQ==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hdnode" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/pbkdf2" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
+"@ethersproject/keccak256@5.6.0", "@ethersproject/keccak256@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.6.0.tgz#fea4bb47dbf8f131c2e1774a1cecbfeb9d606459"
+  integrity sha512-tk56BJ96mdj/ksi7HWZVWGjCq0WVl/QvfhFQNeL8fxhBlGoP+L80uDCiQcpJPd+2XxkivS3lwRm3E0CXTfol0w==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/keccak256@^5.0.3", "@ethersproject/keccak256@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.4.0.tgz#7143b8eea4976080241d2bd92e3b1f1bf7025318"
@@ -870,6 +1033,11 @@
     "@ethersproject/bytes" "^5.5.0"
     js-sha3 "0.8.0"
 
+"@ethersproject/logger@5.6.0", "@ethersproject/logger@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.6.0.tgz#d7db1bfcc22fd2e4ab574cba0bb6ad779a9a3e7a"
+  integrity sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==
+
 "@ethersproject/logger@^5.0.5", "@ethersproject/logger@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.4.1.tgz#503bd33683538b923c578c07d1c2c0dd18672054"
@@ -879,6 +1047,13 @@
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
   integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
+
+"@ethersproject/networks@5.6.2", "@ethersproject/networks@^5.6.0":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.6.2.tgz#2bacda62102c0b1fcee408315f2bed4f6fbdf336"
+  integrity sha512-9uEzaJY7j5wpYGTojGp8U89mSsgQLc40PCMJLMCnFXTs7nhBveZ0t7dbqWUNrepWTszDbFkYD6WlL8DKx5huHA==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/networks@^5.4.0":
   version "5.4.2"
@@ -894,6 +1069,21 @@
   dependencies:
     "@ethersproject/logger" "^5.5.0"
 
+"@ethersproject/pbkdf2@5.6.0", "@ethersproject/pbkdf2@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.6.0.tgz#04fcc2d7c6bff88393f5b4237d906a192426685a"
+  integrity sha512-Wu1AxTgJo3T3H6MIu/eejLFok9TYoSdgwRr5oGY1LTLfmGesDoSx05pemsbrPT2gG4cQME+baTSCp5sEo2erZQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+
+"@ethersproject/properties@5.6.0", "@ethersproject/properties@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.6.0.tgz#38904651713bc6bdd5bdd1b0a4287ecda920fa04"
+  integrity sha512-szoOkHskajKePTJSZ46uHUWWkbv7TzP2ypdEK6jGMqJaEt2sb0jCgfBo0gH0m2HBpRixMuJ6TBRaQCF7a9DoCg==
+  dependencies:
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/properties@^5.0.3", "@ethersproject/properties@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.4.1.tgz#9f051f976ce790142c6261ccb7b826eaae1f2f36"
@@ -907,6 +1097,31 @@
   integrity sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==
   dependencies:
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/providers@5.6.5":
+  version "5.6.5"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.6.5.tgz#aefecf78459817a323452e05a16d56afcf807e27"
+  integrity sha512-TRS+c2Ud+cMpWodmGAc9xbnYRPWzRNYt2zkCSnj58nJoamBQ6x4cUbBeo0lTC3y+6RDVIBeJv18OqsDbSktLVg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/basex" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/networks" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/web" "^5.6.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
 
 "@ethersproject/providers@^5.5.2":
   version "5.5.2"
@@ -933,6 +1148,14 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
+"@ethersproject/random@5.6.0", "@ethersproject/random@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.6.0.tgz#1505d1ab6a250e0ee92f436850fa3314b2cb5ae6"
+  integrity sha512-si0PLcLjq+NG/XHSZz90asNf+YfKEqJGVdxoEkSukzbnBgC8rydbgbUgBbBGLeHN4kAJwUFEKsu3sCXT93YMsw==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/random@^5.5.0":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.5.1.tgz#7cdf38ea93dc0b1ed1d8e480ccdaf3535c555415"
@@ -940,6 +1163,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/rlp@5.6.0", "@ethersproject/rlp@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.6.0.tgz#55a7be01c6f5e64d6e6e7edb6061aa120962a717"
+  integrity sha512-dz9WR1xpcTL+9DtOT/aDO+YyxSSdO8YIS0jyZwHHSlAmnxA6cKU3TrTd4Xc/bHayctxTgGLYNuVVoiXE4tTq1g==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
 
 "@ethersproject/rlp@^5.4.0":
   version "5.4.0"
@@ -957,6 +1188,15 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
 
+"@ethersproject/sha2@5.6.0", "@ethersproject/sha2@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.6.0.tgz#364c4c11cc753bda36f31f001628706ebadb64d9"
+  integrity sha512-1tNWCPFLu1n3JM9t4/kytz35DkuF9MxqkGGEHNauEbaARdm2fafnOyw1s0tIQDPKF/7bkP1u3dbrmjpn5CelyA==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    hash.js "1.1.7"
+
 "@ethersproject/sha2@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.5.0.tgz#a40a054c61f98fd9eee99af2c3cc6ff57ec24db7"
@@ -964,6 +1204,18 @@
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.6.1", "@ethersproject/signing-key@^5.6.0":
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.6.1.tgz#31b0a531520616254eb0465b9443e49515c4d457"
+  integrity sha512-XvqQ20DH0D+bS3qlrrgh+axRMth5kD1xuvqUQUTeezxUTXBOeR6hWz2/C6FBEu39FRytyybIWrYf7YLSAKr1LQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
     hash.js "1.1.7"
 
 "@ethersproject/signing-key@^5.4.0":
@@ -990,6 +1242,27 @@
     elliptic "6.5.4"
     hash.js "1.1.7"
 
+"@ethersproject/solidity@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.6.0.tgz#64657362a596bf7f5630bdc921c07dd78df06dc3"
+  integrity sha512-YwF52vTNd50kjDzqKaoNNbC/r9kMDPq3YzDWmsjFTRBcIF1y4JCQJ8gB30wsTfHbaxgxelI5BfxQSxD/PbJOww==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/sha2" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
+"@ethersproject/strings@5.6.0", "@ethersproject/strings@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.6.0.tgz#9891b26709153d996bf1303d39a7f4bc047878fd"
+  integrity sha512-uv10vTtLTZqrJuqBZR862ZQjTIa724wGPWQqZrofaPI/kUsf53TBG0I0D+hQ1qyNtllbNzaW+PDPHHUI6/65Mg==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+
 "@ethersproject/strings@^5.0.4", "@ethersproject/strings@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.4.0.tgz#fb12270132dd84b02906a8d895ae7e7fa3d07d9a"
@@ -1007,6 +1280,21 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/constants" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
+
+"@ethersproject/transactions@5.6.0", "@ethersproject/transactions@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.6.0.tgz#4b594d73a868ef6e1529a2f8f94a785e6791ae4e"
+  integrity sha512-4HX+VOhNjXHZyGzER6E/LVI2i6lf9ejYeWD6l4g50AdmimyuStKc39kvKf1bXWQMg7QNVh+uC7dYwtaZ02IXeg==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/rlp" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
 
 "@ethersproject/transactions@^5.0.0-beta.135", "@ethersproject/transactions@^5.4.0":
   version "5.4.0"
@@ -1038,6 +1326,47 @@
     "@ethersproject/rlp" "^5.5.0"
     "@ethersproject/signing-key" "^5.5.0"
 
+"@ethersproject/units@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.6.0.tgz#e5cbb1906988f5740254a21b9ded6bd51e826d9c"
+  integrity sha512-tig9x0Qmh8qbo1w8/6tmtyrm/QQRviBh389EQ+d8fP4wDsBrJBf08oZfoiz1/uenKK9M78yAP4PoR7SsVoTjsw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/constants" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+
+"@ethersproject/wallet@5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.6.0.tgz#33d11a806d783864208f348709a5a3badac8e22a"
+  integrity sha512-qMlSdOSTyp0MBeE+r7SUhr1jjDlC1zAXB8VD84hCnpijPQiSNbxr6GdiLXxpUs8UKzkDiNYYC5DRI3MZr+n+tg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.6.0"
+    "@ethersproject/abstract-signer" "^5.6.0"
+    "@ethersproject/address" "^5.6.0"
+    "@ethersproject/bignumber" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/hdnode" "^5.6.0"
+    "@ethersproject/json-wallets" "^5.6.0"
+    "@ethersproject/keccak256" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/random" "^5.6.0"
+    "@ethersproject/signing-key" "^5.6.0"
+    "@ethersproject/transactions" "^5.6.0"
+    "@ethersproject/wordlists" "^5.6.0"
+
+"@ethersproject/web@5.6.0", "@ethersproject/web@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.6.0.tgz#4bf8b3cbc17055027e1a5dd3c357e37474eaaeb8"
+  integrity sha512-G/XHj0hV1FxI2teHRfCGvfBUHFmU+YOSbCxlAMqJklxSa7QMiHFQfAxvwY2PFqgvdkxEKwRNr/eCjfAPEm2Ctg==
+  dependencies:
+    "@ethersproject/base64" "^5.6.0"
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
+
 "@ethersproject/web@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.4.0.tgz#49fac173b96992334ed36a175538ba07a7413d1f"
@@ -1059,6 +1388,17 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
+
+"@ethersproject/wordlists@5.6.0", "@ethersproject/wordlists@^5.6.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.6.0.tgz#79e62c5276e091d8575f6930ba01a29218ded032"
+  integrity sha512-q0bxNBfIX3fUuAo9OmjlEYxP40IB8ABgb7HjEZCL5IKubzV3j30CWi2rqQbjTS2HfoyQbfINoKcTVWP4ejwR7Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.6.0"
+    "@ethersproject/hash" "^5.6.0"
+    "@ethersproject/logger" "^5.6.0"
+    "@ethersproject/properties" "^5.6.0"
+    "@ethersproject/strings" "^5.6.0"
 
 "@gar/promisify@^1.0.1":
   version "1.1.2"
@@ -3162,6 +3502,11 @@ add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
+
+aes-js@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
+  integrity sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
 
 aes-js@^3.1.2:
   version "3.1.2"
@@ -5313,6 +5658,13 @@ eth-lib@^0.1.26:
     ws "^3.0.0"
     xhr-request-promise "^0.1.2"
 
+eth-testing@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eth-testing/-/eth-testing-1.0.0.tgz#7020da1e4c873fec84cd2c437f8cd277b6b2d6e1"
+  integrity sha512-HaMC1EukC1e47cqV3apZhkeO7N0qQLHGKsyCG1x1yw36w5Tud+yCSgyft5+8eEZ5oytAZV8aVTuw0LR93/ks1w==
+  dependencies:
+    ethers "^5.5.4"
+
 ethereum-bloom-filters@^1.0.6:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz#3ca07f4aed698e75bd134584850260246a5fed8a"
@@ -5402,6 +5754,42 @@ ethereumjs-util@^7.1.3:
     create-hash "^1.1.2"
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
+
+ethers@^5.5.4:
+  version "5.6.5"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.6.5.tgz#3185ac7815dc640993408adf6f133ffabfbcbb63"
+  integrity sha512-9CTmplO9bv0s/aPw3HB3txGzKz3tUSI2EfO4dJo0W2WvaEq1ArgsEX6obV+bj5X3yY+Zgb1kAux8TDtJKe1FaA==
+  dependencies:
+    "@ethersproject/abi" "5.6.1"
+    "@ethersproject/abstract-provider" "5.6.0"
+    "@ethersproject/abstract-signer" "5.6.0"
+    "@ethersproject/address" "5.6.0"
+    "@ethersproject/base64" "5.6.0"
+    "@ethersproject/basex" "5.6.0"
+    "@ethersproject/bignumber" "5.6.0"
+    "@ethersproject/bytes" "5.6.1"
+    "@ethersproject/constants" "5.6.0"
+    "@ethersproject/contracts" "5.6.0"
+    "@ethersproject/hash" "5.6.0"
+    "@ethersproject/hdnode" "5.6.0"
+    "@ethersproject/json-wallets" "5.6.0"
+    "@ethersproject/keccak256" "5.6.0"
+    "@ethersproject/logger" "5.6.0"
+    "@ethersproject/networks" "5.6.2"
+    "@ethersproject/pbkdf2" "5.6.0"
+    "@ethersproject/properties" "5.6.0"
+    "@ethersproject/providers" "5.6.5"
+    "@ethersproject/random" "5.6.0"
+    "@ethersproject/rlp" "5.6.0"
+    "@ethersproject/sha2" "5.6.0"
+    "@ethersproject/signing-key" "5.6.1"
+    "@ethersproject/solidity" "5.6.0"
+    "@ethersproject/strings" "5.6.0"
+    "@ethersproject/transactions" "5.6.0"
+    "@ethersproject/units" "5.6.0"
+    "@ethersproject/wallet" "5.6.0"
+    "@ethersproject/web" "5.6.0"
+    "@ethersproject/wordlists" "5.6.0"
 
 ethjs-unit@0.1.6:
   version "0.1.6"
@@ -9752,7 +10140,7 @@ scheduler@^0.22.0:
   dependencies:
     loose-envify "^1.1.0"
 
-scrypt-js@^3.0.0, scrypt-js@^3.0.1:
+scrypt-js@3.0.1, scrypt-js@^3.0.0, scrypt-js@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
   integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==


### PR DESCRIPTION
## Testing
### Add Basic Testing that UI modal appears when pressed

### Add some basic Tests for Connectors 

use `eth-testing` library to test Metamask connector (as such its the best tested

unfortunately that library not working for testing our other Connectors. 

## Non Test Change
 when connecting via MetaMask changes the default account to be obtained via `ethereum.request({
      method: 'eth_requestAccounts',
    });
` 
rather than `this.kit.connection.web3.eth.getAccounts();`


 changed updateKitWithNetwork as it was not working like i would expect
 
 fixes #177 