### PR TITLE
feat: wallet test plan

### DIFF
--- a/packages/example/components/test-plan/connect-wallet.tsx
+++ b/packages/example/components/test-plan/connect-wallet.tsx
@@ -1,0 +1,38 @@
+import { Mainnet, useCelo } from '@celo/react-celo';
+import React from 'react';
+
+import { PrimaryButton } from '..';
+import { SuccessIcon } from './success-icon';
+import { Header, Result, TestBlock } from './ui';
+import { Status, useTestStatus } from './useTestStatus';
+
+export function ConnectWalletCheck() {
+  const { connect, address, updateNetwork } = useCelo();
+  const { status, errorMessage, wrapActionWithStatus } = useTestStatus();
+
+  const onConnectWallet = wrapActionWithStatus(async () => {
+    await updateNetwork(Mainnet);
+    await connect();
+  });
+
+  return (
+    <TestBlock status={status}>
+      <Header>Connect wallet (Mainnet)</Header>
+      <PrimaryButton
+        onClick={onConnectWallet}
+        disabled={status !== Status.NotStarted}
+      >
+        Connect wallet
+      </PrimaryButton>
+      <Result status={status}>
+        <Result.Default>
+          <p>Press the button above to choose a wallet to connect to.</p>
+        </Result.Default>
+        <Result.Success>
+          <SuccessIcon /> Connected to {address}
+        </Result.Success>
+        <Result.Error>{errorMessage}</Result.Error>
+      </Result>
+    </TestBlock>
+  );
+}

--- a/packages/example/components/test-plan/error-icon.tsx
+++ b/packages/example/components/test-plan/error-icon.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export function ErrorIcon() {
+  return (
+    <svg
+      className="inline"
+      height="12px"
+      version="1.1"
+      viewBox="0 0 14 14"
+      width="12px"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title />
+      <desc />
+      <defs />
+      <g
+        fill="none"
+        fillRule="evenodd"
+        id="Page-1"
+        stroke="none"
+        strokeWidth="1"
+      >
+        <g
+          fill="#f94144"
+          id="Core"
+          transform="translate(-341.000000, -89.000000)"
+        >
+          <g id="close" transform="translate(341.000000, 89.000000)">
+            <path
+              d="M14,1.4 L12.6,0 L7,5.6 L1.4,0 L0,1.4 L5.6,7 L0,12.6 L1.4,14 L7,8.4 L12.6,14 L14,12.6 L8.4,7 L14,1.4 Z"
+              id="Shape"
+            />
+          </g>
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/packages/example/components/test-plan/success-icon.tsx
+++ b/packages/example/components/test-plan/success-icon.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export function SuccessIcon() {
+  return (
+    <svg
+      className="inline"
+      height="15px"
+      version="1.1"
+      viewBox="0 0 18 15"
+      width="15px"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title />
+      <desc />
+      <defs />
+      <g
+        fill="none"
+        fillRule="evenodd"
+        id="Page-1"
+        stroke="none"
+        strokeWidth="1"
+      >
+        <g
+          fill="#43aa8b"
+          id="Core"
+          transform="translate(-423.000000, -47.000000)"
+        >
+          <g id="check" transform="translate(423.000000, 47.500000)">
+            <path
+              d="M6,10.2 L1.8,6 L0.4,7.4 L6,13 L18,1 L16.6,-0.4 L6,10.2 Z"
+              id="Shape"
+            />
+          </g>
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/packages/example/components/test-plan/switch-networks.tsx
+++ b/packages/example/components/test-plan/switch-networks.tsx
@@ -1,0 +1,43 @@
+import { Alfajores, useCelo } from '@celo/react-celo';
+import { useEffect, useState } from 'react';
+
+import { PrimaryButton } from '../buttons';
+import { SuccessIcon } from './success-icon';
+import { Header, Result, TestBlock } from './ui';
+import { useTestStatus } from './useTestStatus';
+
+export function SwitchNetwork() {
+  const { updateNetwork, network, address } = useCelo();
+  const [disabled, setDisabled] = useState(true);
+  const { status, errorMessage, wrapActionWithStatus } = useTestStatus();
+
+  const onSwitchNetworks = wrapActionWithStatus(async () => {
+    await updateNetwork(Alfajores);
+  });
+
+  useEffect(() => {
+    setDisabled(!address);
+  }, [address]);
+
+  return (
+    <TestBlock status={status}>
+      <Header>Switch network</Header>
+      <PrimaryButton onClick={onSwitchNetworks} disabled={disabled}>
+        Test switching networks
+      </PrimaryButton>
+      <Result status={status}>
+        <Result.Default>
+          <>
+            <p>Currently connected to {network.name}.</p>
+            <br />
+            <p>Press the button above to connect to Alfajores network.</p>
+          </>
+        </Result.Default>
+        <Result.Success>
+          <SuccessIcon /> Switched to Alfajores
+        </Result.Success>
+        <Result.Error>{errorMessage}</Result.Error>
+      </Result>
+    </TestBlock>
+  );
+}

--- a/packages/example/components/test-plan/ui.tsx
+++ b/packages/example/components/test-plan/ui.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { ErrorIcon } from './error-icon';
+
+import { Status } from './useTestStatus';
+
+export function TestTag({ type }: { type: Status }) {
+  const getText = (type: Status) => {
+    return type.replace('-', ' ');
+  };
+
+  return <span className={`test-tag ${type}`}>{getText(type)}</span>;
+}
+
+export function TestBlock({
+  status,
+  children,
+}: React.PropsWithChildren<{ status: Status }>) {
+  return (
+    <div className="test-block">
+      <div className="tag-column">
+        <TestTag type={status} />
+      </div>
+
+      <div className="test-instructions">{children}</div>
+    </div>
+  );
+}
+
+export const Header: React.FC = (props) => (
+  <h3 className="font-semibold text-2xl" {...props} />
+);
+
+export const Text: React.FC = (props) => (
+  <div className="text-slate-600 mt-2" {...props} />
+);
+
+const ResultContext = React.createContext('');
+
+function useResultContext() {
+  const context = React.useContext(ResultContext);
+  if (!context) {
+    throw new Error('Cannot use this element outside the Result component');
+  }
+  return context;
+}
+
+export function Result(props: React.PropsWithChildren<{ status: Status }>) {
+  return (
+    <ResultContext.Provider value={props.status}>
+      <div className="test-result">{props.children}</div>
+    </ResultContext.Provider>
+  );
+}
+
+export const Success: React.FC = (props) => {
+  const context = useResultContext();
+  return context === Status.Success ? (
+    <p className="text-[#43aa8b]">{props.children}</p>
+  ) : null;
+};
+
+export const ErrorText: React.FC = (props) => {
+  const context = useResultContext();
+  return context === Status.Error ? (
+    <p className="text-[#f94144]">
+      <ErrorIcon /> {props.children}
+    </p>
+  ) : null;
+};
+
+export const Default: React.FC = (props) => {
+  const context = useResultContext();
+  return context === Status.NotStarted || context === Status.Pending ? (
+    <>{props.children}</>
+  ) : null;
+};
+
+Result.Success = Success;
+Result.Error = ErrorText;
+Result.Default = Default;

--- a/packages/example/components/test-plan/useTestStatus.tsx
+++ b/packages/example/components/test-plan/useTestStatus.tsx
@@ -1,0 +1,71 @@
+import { useCelo } from '@celo/react-celo';
+import { useEffect, useMemo, useState } from 'react';
+
+export enum Status {
+  NotStarted = 'not-started',
+  Success = 'success',
+  Error = 'error',
+  Pending = 'pending',
+}
+
+function hasMessage(error: unknown): error is { message: string } {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  return 'message' in error;
+}
+
+export const useTestStatus = () => {
+  const { address } = useCelo();
+
+  const [status, setStatus] = useState<Status>(Status.NotStarted);
+
+  const set = useMemo(() => {
+    return {
+      success: () => {
+        setStatus(Status.Success);
+      },
+      error: (error: unknown) => {
+        setStatus(Status.Error);
+
+        if (hasMessage(error)) {
+          setErrorMessage(error.message);
+        } else {
+          setErrorMessage(JSON.stringify(error));
+        }
+      },
+      pending: () => setStatus(Status.Pending),
+      notStarted: () => setStatus(Status.NotStarted),
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!address) {
+      set.notStarted();
+    }
+
+    return () => {
+      set.notStarted();
+    };
+  }, [address, set]);
+
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const wrapActionWithStatus = (action: () => Promise<void>) => async () => {
+    set.pending();
+    try {
+      await action();
+      set.success();
+    } catch (error) {
+      set.error(error);
+    }
+  };
+
+  return {
+    status,
+    errorMessage,
+    setStatus: set,
+    wrapActionWithStatus,
+  };
+};

--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -32,7 +32,7 @@ function MyApp({ Component, pageProps, router }: AppProps): React.ReactElement {
           },
         }}
       />
-      <div>
+      <div className="max-w-screen-sm mx-auto py-10 md:py-20 px-4">
         <Component {...pageProps} />
       </div>
     </CeloProvider>

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -197,7 +197,7 @@ export default function Home(): React.ReactElement {
         </label>
       </div>
 
-      <main className="max-w-screen-sm mx-auto py-10 md:py-20 px-4">
+      <main>
         <div className="font-semibold text-2xl">react-celo</div>
         <div className="text-slate-600 mt-2">
           A{' '}

--- a/packages/example/pages/wallet-test-plan.tsx
+++ b/packages/example/pages/wallet-test-plan.tsx
@@ -1,0 +1,32 @@
+import { CeloProvider, Mainnet } from '@celo/react-celo';
+import React from 'react';
+
+import { ConnectWalletCheck } from '../components/test-plan/connect-wallet';
+import { SwitchNetwork } from '../components/test-plan/switch-networks';
+
+export default function WalletTestPlan(): React.ReactElement {
+  return (
+    <CeloProvider
+      dapp={{
+        name: 'Wallet test plan',
+        description: 'Wallet test plan',
+        url: 'https://react-celo.vercel.app/wallet-test-plan',
+        icon: 'https://react-celo.vercel.app/favicon.ico',
+      }}
+      network={Mainnet}
+      connectModal={{
+        providersOptions: { searchable: true },
+      }}
+    >
+      <div>
+        <div className="font-semibold text-2xl">Wallet Test Plan</div>
+        <div className="text-slate-600 mt-2">
+          A set of steps to help verify how well a given wallet interacts with
+          react-celo.
+        </div>
+        <ConnectWalletCheck />
+        <SwitchNetwork />
+      </div>
+    </CeloProvider>
+  );
+}

--- a/packages/example/pages/wallet.tsx
+++ b/packages/example/pages/wallet.tsx
@@ -443,7 +443,7 @@ export default function Wallet(): React.ReactElement {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main className="max-w-screen-sm mx-auto py-10 md:py-20 px-4">
+      <main>
         <div className="font-semibold text-2xl">react-celo wallet</div>
 
         <input

--- a/packages/example/styles/global.css
+++ b/packages/example/styles/global.css
@@ -79,3 +79,60 @@ input:checked + .slider:before {
 .slider.round:before {
   border-radius: 50%;
 }
+
+.test-tag {
+  text-transform: lowercase;
+  display: inline-block;
+  border-radius: 10px;
+  padding: 2px 10px;
+  height: max-content;
+  transform: translate(0, 6px);
+}
+
+.success {
+  background: #43aa8b;
+  color: white;
+}
+
+.success-text {
+  color: #43aa8b;
+}
+
+.not-started {
+  background: #577590;
+  color: white;
+}
+
+.error {
+  background: #f94144;
+  color: white;
+}
+
+.pending {
+  background-color: #f9c74f;
+  color: black;
+}
+
+.test-block {
+  display: flex;
+  margin-top: 20px;
+}
+
+.test-instructions {
+  margin-left: 20px;
+}
+
+.test-result {
+  display: inline-block;
+  padding: 10px;
+  font-size: 13px;
+  border-radius: 4px;
+  border: 1px solid #dbdbdb;
+  width: 100%;
+  margin-top: 20px;
+}
+
+.tag-column {
+  min-width: 100px;
+  text-align: right;
+}


### PR DESCRIPTION
### Overview

Opening a draft PR to get early feedback. I only added 2 basic tests, the connect and switching networks.

#### Decisions I made:
- Called it a test plan instead of test flight, because I associate test flight with mobile testing (from iOS testflight)
- For now, I made the tests isolated, but this may change as some tests will depend on one another
- I didn't add a reset button yet, so rerunning the test requires reloading the page.
- Grouped all UI components into one file to reduce the number of separate files for components that are just UI related

#### Problems found
- Switching networks: initially I wanted to switch networks twice, from Mainnet to Alfajores and then back to Mainnet, but this caused a loop in Metamask because even though the promise ended, Metamask was still processing it.
- For some reason, the values returned from `useCelo` (`address`/`network`) do not trigger a re-render and because of that, Next throws a hydration error. As a workaround, I created local state variables that change as those values change. Not ideal, but it stopped the error for now. If relevant enough, we could investigate further.


### Demo 

![Kapture 2022-05-20 at 16 21 21](https://user-images.githubusercontent.com/21973269/169548673-93aa320e-81db-419f-92ab-9c559a6a0a56.gif)



