### PR TITLE
Add Aliases for old function names 

### DIFF
--- a/packages/react-celo/src/react-celo-provider.tsx
+++ b/packages/react-celo/src/react-celo-provider.tsx
@@ -146,6 +146,12 @@ export const CeloProvider: React.FC<CeloProviderProps> = ({
   );
 };
 
+/**
+ *
+ * @deprecated Use the alias {@link CeloProvider} Component instead.
+ */
+export const ContractKitProvider = CeloProvider;
+
 export interface CeloProviderProps {
   children: ReactNode;
   dapp: Dapp;

--- a/packages/react-celo/src/use-celo.tsx
+++ b/packages/react-celo/src/use-celo.tsx
@@ -98,6 +98,12 @@ export function useCelo<CC = undefined>(): UseCelo {
   };
 }
 
+/**
+ *
+ * @deprecated Use the alias {@link useCelo} hook instead.
+ */
+export const useContractKit = useCelo;
+
 interface UseCeloInternal extends UseCelo {
   connectionCallback: Maybe<(connector: Connector | false) => void>;
   initConnector: (connector: Connector) => Promise<void>;
@@ -105,7 +111,7 @@ interface UseCeloInternal extends UseCelo {
 }
 
 /**
- * useCelo with internal methods exposed. Package use only.
+ * @internal useCelo with internal methods exposed. Package use only.
  */
 export const useCeloInternal = (): UseCeloInternal => {
   const [


### PR DESCRIPTION
add useContrakit == useCelo and ContractKitProvider == CeloProvider back so its simpler to upgrade to v4