### PR TITLE
feat: wallet test plan page

### DIFF
--- a/packages/example/components/test-plan/connect-wallet.tsx
+++ b/packages/example/components/test-plan/connect-wallet.tsx
@@ -1,0 +1,38 @@
+import { Mainnet, useCelo } from '@celo/react-celo';
+import React from 'react';
+
+import { PrimaryButton } from '..';
+import { SuccessIcon } from './success-icon';
+import { Header, Result, TestBlock } from './ui';
+import { Status, useTestStatus } from './useTestStatus';
+
+export function ConnectWalletCheck() {
+  const { connect, address, updateNetwork } = useCelo();
+  const { status, errorMessage, wrapActionWithStatus } = useTestStatus();
+
+  const onConnectWallet = wrapActionWithStatus(async () => {
+    await updateNetwork(Mainnet);
+    await connect();
+  });
+
+  return (
+    <TestBlock status={status}>
+      <Header>Connect wallet (Mainnet)</Header>
+      <PrimaryButton
+        onClick={onConnectWallet}
+        disabled={status !== Status.NotStarted}
+      >
+        Connect wallet
+      </PrimaryButton>
+      <Result status={status}>
+        <Result.Default>
+          <p>Press the button above to choose a wallet to connect to.</p>
+        </Result.Default>
+        <Result.Success>
+          <SuccessIcon /> Connected to {address}
+        </Result.Success>
+        <Result.Error>{errorMessage}</Result.Error>
+      </Result>
+    </TestBlock>
+  );
+}

--- a/packages/example/components/test-plan/connect-wallet.tsx
+++ b/packages/example/components/test-plan/connect-wallet.tsx
@@ -1,9 +1,8 @@
 import { Mainnet, useCelo } from '@celo/react-celo';
 import React from 'react';
 
-import { PrimaryButton } from '..';
 import { SuccessIcon } from './success-icon';
-import { Header, Result, TestBlock } from './ui';
+import { Result, TestBlock } from './ui';
 import { Status, useTestStatus } from './useTestStatus';
 
 export function ConnectWalletCheck() {
@@ -16,14 +15,12 @@ export function ConnectWalletCheck() {
   });
 
   return (
-    <TestBlock status={status}>
-      <Header>Connect wallet (Mainnet)</Header>
-      <PrimaryButton
-        onClick={onConnectWallet}
-        disabled={status !== Status.NotStarted}
-      >
-        Connect wallet
-      </PrimaryButton>
+    <TestBlock
+      status={status}
+      title="Connect wallet (Mainnet)"
+      disabledTest={status !== Status.NotStarted}
+      onRunTest={onConnectWallet}
+    >
       <Result status={status}>
         <Result.Default>
           <p>Press the button above to choose a wallet to connect to.</p>

--- a/packages/example/components/test-plan/connect-wallet.tsx
+++ b/packages/example/components/test-plan/connect-wallet.tsx
@@ -1,5 +1,5 @@
 import { Mainnet, useCelo } from '@celo/react-celo';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { SuccessIcon } from './success-icon';
 import { Result, TestBlock } from './ui';
@@ -7,12 +7,19 @@ import { Status, useTestStatus } from './useTestStatus';
 
 export function ConnectWalletCheck() {
   const { connect, address, updateNetwork } = useCelo();
-  const { status, errorMessage, wrapActionWithStatus } = useTestStatus();
+  const { status, errorMessage, wrapActionWithStatus, setStatus } =
+    useTestStatus();
 
   const onConnectWallet = wrapActionWithStatus(async () => {
     await updateNetwork(Mainnet);
     await connect();
   });
+
+  useEffect(() => {
+    if (address) {
+      setStatus.success();
+    }
+  }, [address, setStatus]);
 
   return (
     <TestBlock

--- a/packages/example/components/test-plan/error-icon.tsx
+++ b/packages/example/components/test-plan/error-icon.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export function ErrorIcon() {
+  return (
+    <svg
+      className="inline"
+      height="12px"
+      version="1.1"
+      viewBox="0 0 14 14"
+      width="12px"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title />
+      <desc />
+      <defs />
+      <g
+        fill="none"
+        fillRule="evenodd"
+        id="Page-1"
+        stroke="none"
+        strokeWidth="1"
+      >
+        <g
+          fill="#f94144"
+          id="Core"
+          transform="translate(-341.000000, -89.000000)"
+        >
+          <g id="close" transform="translate(341.000000, 89.000000)">
+            <path
+              d="M14,1.4 L12.6,0 L7,5.6 L1.4,0 L0,1.4 L5.6,7 L0,12.6 L1.4,14 L7,8.4 L12.6,14 L14,12.6 L8.4,7 L14,1.4 Z"
+              id="Shape"
+            />
+          </g>
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/packages/example/components/test-plan/error-icon.tsx
+++ b/packages/example/components/test-plan/error-icon.tsx
@@ -4,10 +4,10 @@ export function ErrorIcon() {
   return (
     <svg
       className="inline"
-      height="12px"
+      height="15px"
       version="1.1"
-      viewBox="0 0 14 14"
-      width="12px"
+      viewBox="0 0 20 20"
+      width="15px"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title />
@@ -23,11 +23,11 @@ export function ErrorIcon() {
         <g
           fill="#f94144"
           id="Core"
-          transform="translate(-341.000000, -89.000000)"
+          transform="translate(-380.000000, -44.000000)"
         >
-          <g id="close" transform="translate(341.000000, 89.000000)">
+          <g id="cancel" transform="translate(380.000000, 44.000000)">
             <path
-              d="M14,1.4 L12.6,0 L7,5.6 L1.4,0 L0,1.4 L5.6,7 L0,12.6 L1.4,14 L7,8.4 L12.6,14 L14,12.6 L8.4,7 L14,1.4 Z"
+              d="M10,0 C4.5,0 0,4.5 0,10 C0,15.5 4.5,20 10,20 C15.5,20 20,15.5 20,10 C20,4.5 15.5,0 10,0 L10,0 Z M15,13.6 L13.6,15 L10,11.4 L6.4,15 L5,13.6 L8.6,10 L5,6.4 L6.4,5 L10,8.6 L13.6,5 L15,6.4 L11.4,10 L15,13.6 L15,13.6 Z"
               id="Shape"
             />
           </g>

--- a/packages/example/components/test-plan/send-transaction.tsx
+++ b/packages/example/components/test-plan/send-transaction.tsx
@@ -1,6 +1,6 @@
 import { useCelo } from '@celo/react-celo';
 
-import { sendTransaction } from '../../utils/send-transaction';
+import { sendTestTransaction } from '../../utils/send-test-transaction';
 import { SuccessIcon } from './success-icon';
 import { Result, TestBlock } from './ui';
 import { useDisabledTest } from './useDisabledTest';
@@ -13,7 +13,7 @@ export function SendTransaction() {
 
   const onRunTest = wrapActionWithStatus(async () => {
     setDisabled(true);
-    await sendTransaction(performActions);
+    await sendTestTransaction(performActions);
   });
 
   return (

--- a/packages/example/components/test-plan/send-transaction.tsx
+++ b/packages/example/components/test-plan/send-transaction.tsx
@@ -1,0 +1,38 @@
+import { useCelo } from '@celo/react-celo';
+
+import { sendTransaction } from '../../utils/send-transaction';
+import { SuccessIcon } from './success-icon';
+import { Result, TestBlock } from './ui';
+import { useDisabledTest } from './useDisabledTest';
+import { useTestStatus } from './useTestStatus';
+
+export function SendTransaction() {
+  const { performActions } = useCelo();
+  const { status, errorMessage, wrapActionWithStatus } = useTestStatus();
+  const [disabled, setDisabled] = useDisabledTest();
+
+  const onRunTest = wrapActionWithStatus(async () => {
+    setDisabled(true);
+    await sendTransaction(performActions);
+  });
+
+  return (
+    <TestBlock
+      status={status}
+      title="Send transaction"
+      disabledTest={disabled}
+      onRunTest={onRunTest}
+    >
+      <Result status={status}>
+        <p>This sends a very small transaction to impact market contract.</p>
+        <Result.Default>
+          <p>You'll need to approve the transaction in the wallet.</p>
+        </Result.Default>
+        <Result.Success>
+          <SuccessIcon /> Transaction sent
+        </Result.Success>
+        <Result.Error>{errorMessage}</Result.Error>
+      </Result>
+    </TestBlock>
+  );
+}

--- a/packages/example/components/test-plan/success-icon.tsx
+++ b/packages/example/components/test-plan/success-icon.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export function SuccessIcon() {
+  return (
+    <svg
+      className="inline"
+      height="15px"
+      version="1.1"
+      viewBox="0 0 18 15"
+      width="15px"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <title />
+      <desc />
+      <defs />
+      <g
+        fill="none"
+        fillRule="evenodd"
+        id="Page-1"
+        stroke="none"
+        strokeWidth="1"
+      >
+        <g
+          fill="#43aa8b"
+          id="Core"
+          transform="translate(-423.000000, -47.000000)"
+        >
+          <g id="check" transform="translate(423.000000, 47.500000)">
+            <path
+              d="M6,10.2 L1.8,6 L0.4,7.4 L6,13 L18,1 L16.6,-0.4 L6,10.2 Z"
+              id="Shape"
+            />
+          </g>
+        </g>
+      </g>
+    </svg>
+  );
+}

--- a/packages/example/components/test-plan/success-icon.tsx
+++ b/packages/example/components/test-plan/success-icon.tsx
@@ -4,10 +4,10 @@ export function SuccessIcon() {
   return (
     <svg
       className="inline"
-      height="15px"
+      height="14px"
       version="1.1"
-      viewBox="0 0 18 15"
-      width="15px"
+      viewBox="0 0 20 20"
+      width="14px"
       xmlns="http://www.w3.org/2000/svg"
     >
       <title />
@@ -23,11 +23,11 @@ export function SuccessIcon() {
         <g
           fill="#43aa8b"
           id="Core"
-          transform="translate(-423.000000, -47.000000)"
+          transform="translate(-44.000000, -86.000000)"
         >
-          <g id="check" transform="translate(423.000000, 47.500000)">
+          <g id="check-circle" transform="translate(44.000000, 86.000000)">
             <path
-              d="M6,10.2 L1.8,6 L0.4,7.4 L6,13 L18,1 L16.6,-0.4 L6,10.2 Z"
+              d="M10,0 C4.5,0 0,4.5 0,10 C0,15.5 4.5,20 10,20 C15.5,20 20,15.5 20,10 C20,4.5 15.5,0 10,0 L10,0 Z M8,15 L3,10 L4.4,8.6 L8,12.2 L15.6,4.6 L17,6 L8,15 L8,15 Z"
               id="Shape"
             />
           </g>

--- a/packages/example/components/test-plan/switch-networks.tsx
+++ b/packages/example/components/test-plan/switch-networks.tsx
@@ -8,8 +8,9 @@ import { useTestStatus } from './useTestStatus';
 
 export function SwitchNetwork() {
   const { updateNetwork, network, address } = useCelo();
-  const [disabled, setDisabled] = useState(true);
   const { status, errorMessage, wrapActionWithStatus } = useTestStatus();
+  const [disabled, setDisabled] = useState(true);
+  const [connectedNetwork, setConnectedNetwork] = useState('');
 
   const onSwitchNetworks = wrapActionWithStatus(async () => {
     await updateNetwork(Alfajores);
@@ -18,6 +19,10 @@ export function SwitchNetwork() {
   useEffect(() => {
     setDisabled(!address);
   }, [address]);
+
+  useEffect(() => {
+    setConnectedNetwork(network.name);
+  }, [network.name]);
 
   return (
     <TestBlock status={status}>
@@ -28,7 +33,7 @@ export function SwitchNetwork() {
       <Result status={status}>
         <Result.Default>
           <>
-            <p>Currently connected to {network.name}.</p>
+            <p>Currently connected to {connectedNetwork}.</p>
             <br />
             <p>Press the button above to connect to Alfajores network.</p>
           </>

--- a/packages/example/components/test-plan/switch-networks.tsx
+++ b/packages/example/components/test-plan/switch-networks.tsx
@@ -1,10 +1,9 @@
 import { Alfajores, useCelo } from '@celo/react-celo';
 import { useEffect, useState } from 'react';
 
-import { PrimaryButton } from '../buttons';
 import { SuccessIcon } from './success-icon';
-import { Header, Result, TestBlock } from './ui';
 import { useTestStatus } from './useTestStatus';
+import { Result, TestBlock } from './ui';
 
 export function SwitchNetwork() {
   const { updateNetwork, network, address } = useCelo();
@@ -25,11 +24,12 @@ export function SwitchNetwork() {
   }, [network.name]);
 
   return (
-    <TestBlock status={status}>
-      <Header>Switch network</Header>
-      <PrimaryButton onClick={onSwitchNetworks} disabled={disabled}>
-        Test switching networks
-      </PrimaryButton>
+    <TestBlock
+      status={status}
+      title="Switch network"
+      disabledTest={disabledTest}
+      onRunTest={onSwitchNetworks}
+    >
       <Result status={status}>
         <Result.Default>
           <>

--- a/packages/example/components/test-plan/switch-networks.tsx
+++ b/packages/example/components/test-plan/switch-networks.tsx
@@ -2,26 +2,29 @@ import { Alfajores, useCelo } from '@celo/react-celo';
 import { useEffect, useState } from 'react';
 
 import { SuccessIcon } from './success-icon';
-import { useTestStatus } from './useTestStatus';
 import { Result, TestBlock } from './ui';
+import { useDisabledTest } from './useDisabledTest';
+import { Status, useTestStatus } from './useTestStatus';
 
 export function SwitchNetwork() {
-  const { updateNetwork, network, address } = useCelo();
-  const { status, errorMessage, wrapActionWithStatus } = useTestStatus();
-  const [disabled, setDisabled] = useState(true);
+  const { updateNetwork, network } = useCelo();
+  const { status, errorMessage, wrapActionWithStatus, setStatus } =
+    useTestStatus();
+  const [disabledTest, setDisabledTest] = useDisabledTest();
   const [connectedNetwork, setConnectedNetwork] = useState('');
 
   const onSwitchNetworks = wrapActionWithStatus(async () => {
+    setDisabledTest(true);
     await updateNetwork(Alfajores);
   });
 
   useEffect(() => {
-    setDisabled(!address);
-  }, [address]);
-
-  useEffect(() => {
     setConnectedNetwork(network.name);
-  }, [network.name]);
+    if (status === Status.NotStarted && network.name === Alfajores.name) {
+      setStatus.error('Already set to Alfajores');
+      setDisabledTest(true);
+    }
+  }, [network.name, setStatus, status, setDisabledTest]);
 
   return (
     <TestBlock
@@ -32,11 +35,7 @@ export function SwitchNetwork() {
     >
       <Result status={status}>
         <Result.Default>
-          <>
-            <p>Currently connected to {connectedNetwork}.</p>
-            <br />
-            <p>Press the button above to connect to Alfajores network.</p>
-          </>
+          <p>Currently connected to {connectedNetwork}.</p>
         </Result.Default>
         <Result.Success>
           <SuccessIcon /> Switched to Alfajores

--- a/packages/example/components/test-plan/switch-networks.tsx
+++ b/packages/example/components/test-plan/switch-networks.tsx
@@ -1,0 +1,43 @@
+import { Alfajores, useCelo } from '@celo/react-celo';
+import { useEffect, useState } from 'react';
+
+import { PrimaryButton } from '../buttons';
+import { SuccessIcon } from './success-icon';
+import { Header, Result, TestBlock } from './ui';
+import { useTestStatus } from './useTestStatus';
+
+export function SwitchNetwork() {
+  const { updateNetwork, network, address } = useCelo();
+  const [disabled, setDisabled] = useState(true);
+  const { status, errorMessage, wrapActionWithStatus } = useTestStatus();
+
+  const onSwitchNetworks = wrapActionWithStatus(async () => {
+    await updateNetwork(Alfajores);
+  });
+
+  useEffect(() => {
+    setDisabled(!address);
+  }, [address]);
+
+  return (
+    <TestBlock status={status}>
+      <Header>Switch network</Header>
+      <PrimaryButton onClick={onSwitchNetworks} disabled={disabled}>
+        Test switching networks
+      </PrimaryButton>
+      <Result status={status}>
+        <Result.Default>
+          <>
+            <p>Currently connected to {network.name}.</p>
+            <br />
+            <p>Press the button above to connect to Alfajores network.</p>
+          </>
+        </Result.Default>
+        <Result.Success>
+          <SuccessIcon /> Switched to Alfajores
+        </Result.Success>
+        <Result.Error>{errorMessage}</Result.Error>
+      </Result>
+    </TestBlock>
+  );
+}

--- a/packages/example/components/test-plan/ui.tsx
+++ b/packages/example/components/test-plan/ui.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ErrorIcon } from './error-icon';
+import { SecondaryButton } from '../buttons';
 
 import { Status } from './useTestStatus';
 
@@ -13,15 +14,34 @@ export function TestTag({ type }: { type: Status }) {
 
 export function TestBlock({
   status,
+  title,
+  onRunTest,
+  disabledTest,
   children,
-}: React.PropsWithChildren<{ status: Status }>) {
+}: React.PropsWithChildren<{
+  title: string;
+  status: Status;
+  disabledTest: boolean;
+  onRunTest: () => void;
+}>) {
   return (
     <div className="test-block">
       <div className="tag-column">
         <TestTag type={status} />
       </div>
-
-      <div className="test-instructions">{children}</div>
+      <div className="test-instructions">
+        <div className="flex items-center">
+          <Header>{title}</Header>
+          <SecondaryButton
+            className="underline"
+            onClick={onRunTest}
+            disabled={disabledTest}
+          >
+            Run
+          </SecondaryButton>
+        </div>
+        {children}
+      </div>
     </div>
   );
 }

--- a/packages/example/components/test-plan/ui.tsx
+++ b/packages/example/components/test-plan/ui.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { ErrorIcon } from './error-icon';
 import { SecondaryButton } from '../buttons';
 
+import { ErrorIcon } from './error-icon';
 import { Status } from './useTestStatus';
 
 export function TestTag({ type }: { type: Status }) {
@@ -47,7 +47,7 @@ export function TestBlock({
 }
 
 export const Header: React.FC = (props) => (
-  <h3 className="font-semibold text-2xl" {...props} />
+  <h3 className="font-semibold text-base" {...props} />
 );
 
 export const Text: React.FC = (props) => (
@@ -75,14 +75,16 @@ export function Result(props: React.PropsWithChildren<{ status: Status }>) {
 export const Success: React.FC = (props) => {
   const context = useResultContext();
   return context === Status.Success ? (
-    <p className="text-[#43aa8b]">{props.children}</p>
+    <p className="text-[#43aa8b] flex items-center gap-[5px]">
+      {props.children}
+    </p>
   ) : null;
 };
 
 export const ErrorText: React.FC = (props) => {
   const context = useResultContext();
   return context === Status.Error ? (
-    <p className="text-[#f94144]">
+    <p className="text-[#f94144] flex items-center gap-[5px]">
       <ErrorIcon /> {props.children}
     </p>
   ) : null;

--- a/packages/example/components/test-plan/ui.tsx
+++ b/packages/example/components/test-plan/ui.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { ErrorIcon } from './error-icon';
+
+import { Status } from './useTestStatus';
+
+export function TestTag({ type }: { type: Status }) {
+  const getText = (type: Status) => {
+    return type.replace('-', ' ');
+  };
+
+  return <span className={`test-tag ${type}`}>{getText(type)}</span>;
+}
+
+export function TestBlock({
+  status,
+  children,
+}: React.PropsWithChildren<{ status: Status }>) {
+  return (
+    <div className="test-block">
+      <div className="tag-column">
+        <TestTag type={status} />
+      </div>
+
+      <div className="test-instructions">{children}</div>
+    </div>
+  );
+}
+
+export const Header: React.FC = (props) => (
+  <h3 className="font-semibold text-2xl" {...props} />
+);
+
+export const Text: React.FC = (props) => (
+  <div className="text-slate-600 mt-2" {...props} />
+);
+
+const ResultContext = React.createContext('');
+
+function useResultContext() {
+  const context = React.useContext(ResultContext);
+  if (!context) {
+    throw new Error('Cannot use this element outside the Result component');
+  }
+  return context;
+}
+
+export function Result(props: React.PropsWithChildren<{ status: Status }>) {
+  return (
+    <ResultContext.Provider value={props.status}>
+      <div className="test-result">{props.children}</div>
+    </ResultContext.Provider>
+  );
+}
+
+export const Success: React.FC = (props) => {
+  const context = useResultContext();
+  return context === Status.Success ? (
+    <p className="text-[#43aa8b]">{props.children}</p>
+  ) : null;
+};
+
+export const ErrorText: React.FC = (props) => {
+  const context = useResultContext();
+  return context === Status.Error ? (
+    <p className="text-[#f94144]">
+      <ErrorIcon /> {props.children}
+    </p>
+  ) : null;
+};
+
+export const Default: React.FC = (props) => {
+  const context = useResultContext();
+  return context === Status.NotStarted || context === Status.Pending ? (
+    <>{props.children}</>
+  ) : null;
+};
+
+Result.Success = Success;
+Result.Error = ErrorText;
+Result.Default = Default;

--- a/packages/example/components/test-plan/update-fee-currency.tsx
+++ b/packages/example/components/test-plan/update-fee-currency.tsx
@@ -8,17 +8,18 @@ import { useDisabledTest } from './useDisabledTest';
 import { useTestStatus } from './useTestStatus';
 
 export function UpdateFeeCurrency() {
-  const { updateFeeCurrency, feeCurrency, supportsFeeCurrency } = useCelo();
+  const { updateFeeCurrency, feeCurrency, supportsFeeCurrency, address } =
+    useCelo();
   const [disabledTest, setDisabledTest] = useDisabledTest();
   const { status, errorMessage, wrapActionWithStatus, setStatus } =
     useTestStatus();
 
   useEffect(() => {
-    if (supportsFeeCurrency !== undefined && !supportsFeeCurrency) {
+    if (address && supportsFeeCurrency !== undefined && !supportsFeeCurrency) {
       setDisabledTest(true);
       setStatus.error('Wallet does not support updating fee currency.');
     }
-  }, [supportsFeeCurrency, setStatus, setDisabledTest]);
+  }, [address, supportsFeeCurrency, setStatus, setDisabledTest]);
 
   const onUpdateCurrency = wrapActionWithStatus(async () => {
     setDisabledTest(true);

--- a/packages/example/components/test-plan/update-fee-currency.tsx
+++ b/packages/example/components/test-plan/update-fee-currency.tsx
@@ -1,0 +1,52 @@
+import { CeloContract } from '@celo/contractkit';
+import { useCelo } from '@celo/react-celo';
+import { useEffect } from 'react';
+
+import { SuccessIcon } from './success-icon';
+import { Result, TestBlock } from './ui';
+import { useDisabledTest } from './useDisabledTest';
+import { useTestStatus } from './useTestStatus';
+
+export function UpdateFeeCurrency() {
+  const { updateFeeCurrency, feeCurrency, supportsFeeCurrency } = useCelo();
+  const [disabledTest, setDisabledTest] = useDisabledTest();
+  const { status, errorMessage, wrapActionWithStatus, setStatus } =
+    useTestStatus();
+
+  useEffect(() => {
+    if (supportsFeeCurrency !== undefined && !supportsFeeCurrency) {
+      setDisabledTest(true);
+      setStatus.error('Wallet does not support updating fee currency.');
+    }
+  }, [supportsFeeCurrency, setStatus, setDisabledTest]);
+
+  const onUpdateCurrency = wrapActionWithStatus(async () => {
+    setDisabledTest(true);
+    await updateFeeCurrency(CeloContract.StableTokenBRL);
+    if (feeCurrency !== CeloContract.StableTokenBRL) {
+      throw new Error('Fee currency did not update.');
+    }
+  });
+
+  return (
+    <TestBlock
+      status={status}
+      title="Update fee currency"
+      disabledTest={disabledTest}
+      onRunTest={onUpdateCurrency}
+    >
+      <Result status={status}>
+        <p>Fee currency used: {feeCurrency}</p>
+        <Result.Default>
+          <>
+            <p>Change the currency used in transactions.</p>
+          </>
+        </Result.Default>
+        <Result.Success>
+          <SuccessIcon /> Fee currency {feeCurrency}
+        </Result.Success>
+        <Result.Error>{errorMessage}</Result.Error>
+      </Result>
+    </TestBlock>
+  );
+}

--- a/packages/example/components/test-plan/useDisabledTest.tsx
+++ b/packages/example/components/test-plan/useDisabledTest.tsx
@@ -1,0 +1,15 @@
+import { useCelo } from '@celo/react-celo';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+
+export const useDisabledTest = (): [
+  boolean,
+  Dispatch<SetStateAction<boolean>>
+] => {
+  const { address } = useCelo();
+  const [disabled, setDisabled] = useState(true);
+  useEffect(() => {
+    setDisabled(!address);
+  }, [address]);
+
+  return [disabled, setDisabled];
+};

--- a/packages/example/components/test-plan/useTestStatus.tsx
+++ b/packages/example/components/test-plan/useTestStatus.tsx
@@ -1,0 +1,71 @@
+import { useCelo } from '@celo/react-celo';
+import { useEffect, useMemo, useState } from 'react';
+
+export enum Status {
+  NotStarted = 'not-started',
+  Success = 'success',
+  Error = 'error',
+  Pending = 'pending',
+}
+
+function hasMessage(error: unknown): error is { message: string } {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  return 'message' in error;
+}
+
+export const useTestStatus = () => {
+  const { address } = useCelo();
+
+  const [status, setStatus] = useState<Status>(Status.NotStarted);
+
+  const set = useMemo(() => {
+    return {
+      success: () => {
+        setStatus(Status.Success);
+      },
+      error: (error: unknown) => {
+        setStatus(Status.Error);
+
+        if (hasMessage(error)) {
+          setErrorMessage(error.message);
+        } else {
+          setErrorMessage(JSON.stringify(error));
+        }
+      },
+      pending: () => setStatus(Status.Pending),
+      notStarted: () => setStatus(Status.NotStarted),
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!address) {
+      set.notStarted();
+    }
+
+    return () => {
+      set.notStarted();
+    };
+  }, [address, set]);
+
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const wrapActionWithStatus = (action: () => Promise<void>) => async () => {
+    set.pending();
+    try {
+      await action();
+      set.success();
+    } catch (error) {
+      set.error(error);
+    }
+  };
+
+  return {
+    status,
+    errorMessage,
+    setStatus: set,
+    wrapActionWithStatus,
+  };
+};

--- a/packages/example/components/test-plan/useTestStatus.tsx
+++ b/packages/example/components/test-plan/useTestStatus.tsx
@@ -31,6 +31,8 @@ export const useTestStatus = () => {
 
         if (hasMessage(error)) {
           setErrorMessage(error.message);
+        } else if (typeof error === 'string') {
+          setErrorMessage(error);
         } else {
           setErrorMessage(JSON.stringify(error));
         }

--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -32,7 +32,7 @@ function MyApp({ Component, pageProps, router }: AppProps): React.ReactElement {
           },
         }}
       />
-      <div>
+      <div className="max-w-screen-sm mx-auto py-10 md:py-20 px-4">
         <Component {...pageProps} />
       </div>
     </CeloProvider>

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -213,7 +213,7 @@ export default function Home(): React.ReactElement {
         </label>
       </div>
 
-      <main className="max-w-screen-sm mx-auto py-10 md:py-20 px-4">
+      <main>
         <div className="font-semibold text-2xl">react-celo</div>
         <div className="text-slate-600 mt-2">
           A{' '}

--- a/packages/example/pages/wallet-test-plan.tsx
+++ b/packages/example/pages/wallet-test-plan.tsx
@@ -1,0 +1,32 @@
+import { CeloProvider, Mainnet } from '@celo/react-celo';
+import React from 'react';
+
+import { ConnectWalletCheck } from '../components/test-plan/connect-wallet';
+import { SwitchNetwork } from '../components/test-plan/switch-networks';
+
+export default function WalletTestPlan(): React.ReactElement {
+  return (
+    <CeloProvider
+      dapp={{
+        name: 'Wallet test plan',
+        description: 'Wallet test plan',
+        url: 'https://react-celo.vercel.app/wallet-test-plan',
+        icon: 'https://react-celo.vercel.app/favicon.ico',
+      }}
+      network={Mainnet}
+      connectModal={{
+        providersOptions: { searchable: true },
+      }}
+    >
+      <div>
+        <div className="font-semibold text-2xl">Wallet Test Plan</div>
+        <div className="text-slate-600 mt-2">
+          A set of steps to help verify how well a given wallet interacts with
+          react-celo.
+        </div>
+        <ConnectWalletCheck />
+        <SwitchNetwork />
+      </div>
+    </CeloProvider>
+  );
+}

--- a/packages/example/pages/wallet-test-plan.tsx
+++ b/packages/example/pages/wallet-test-plan.tsx
@@ -1,10 +1,13 @@
-import { CeloProvider, Mainnet } from '@celo/react-celo';
+import { CeloProvider, Mainnet, useCelo } from '@celo/react-celo';
 import React from 'react';
 
 import { ConnectWalletCheck } from '../components/test-plan/connect-wallet';
+import { SendTransaction } from '../components/test-plan/send-transaction';
 import { SwitchNetwork } from '../components/test-plan/switch-networks';
+import { UpdateFeeCurrency } from '../components/test-plan/update-fee-currency';
 
 export default function WalletTestPlan(): React.ReactElement {
+  const { destroy } = useCelo();
   return (
     <CeloProvider
       dapp={{
@@ -23,9 +26,22 @@ export default function WalletTestPlan(): React.ReactElement {
         <div className="text-slate-600 mt-2">
           A set of steps to help verify how well a given wallet interacts with
           react-celo.
+          <br />
+          You will need to connect a wallet before being able to run any other
+          test.
+        </div>
+        <div>
+          <button
+            className="inline underline text-purple-700"
+            onClick={destroy}
+          >
+            Disconnect wallet
+          </button>
         </div>
         <ConnectWalletCheck />
         <SwitchNetwork />
+        <UpdateFeeCurrency />
+        <SendTransaction />
       </div>
     </CeloProvider>
   );

--- a/packages/example/pages/wallet.tsx
+++ b/packages/example/pages/wallet.tsx
@@ -443,7 +443,7 @@ export default function Wallet(): React.ReactElement {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <main className="max-w-screen-sm mx-auto py-10 md:py-20 px-4">
+      <main>
         <div className="font-semibold text-2xl">react-celo wallet</div>
 
         <input

--- a/packages/example/styles/global.css
+++ b/packages/example/styles/global.css
@@ -80,3 +80,60 @@ input:checked + .slider:before {
 .slider.round:before {
   border-radius: 50%;
 }
+
+.test-tag {
+  text-transform: lowercase;
+  display: inline-block;
+  border-radius: 10px;
+  padding: 2px 10px;
+  height: max-content;
+  transform: translate(0, 6px);
+}
+
+.success {
+  background: #43aa8b;
+  color: white;
+}
+
+.success-text {
+  color: #43aa8b;
+}
+
+.not-started {
+  background: #577590;
+  color: white;
+}
+
+.error {
+  background: #f94144;
+  color: white;
+}
+
+.pending {
+  background-color: #f9c74f;
+  color: black;
+}
+
+.test-block {
+  display: flex;
+  margin-top: 20px;
+}
+
+.test-instructions {
+  margin-left: 20px;
+}
+
+.test-result {
+  display: inline-block;
+  padding: 10px;
+  font-size: 13px;
+  border-radius: 4px;
+  border: 1px solid #dbdbdb;
+  width: 100%;
+  margin-top: 20px;
+}
+
+.tag-column {
+  min-width: 100px;
+  text-align: right;
+}

--- a/packages/example/styles/global.css
+++ b/packages/example/styles/global.css
@@ -87,7 +87,8 @@ input:checked + .slider:before {
   border-radius: 10px;
   padding: 2px 10px;
   height: max-content;
-  transform: translate(0, 6px);
+  transform: translate(0, 9px);
+  font-size: 14px;
 }
 
 .success {
@@ -130,7 +131,6 @@ input:checked + .slider:before {
   border-radius: 4px;
   border: 1px solid #dbdbdb;
   width: 100%;
-  margin-top: 20px;
 }
 
 .tag-column {

--- a/packages/example/utils/send-test-transaction.ts
+++ b/packages/example/utils/send-test-transaction.ts
@@ -1,7 +1,7 @@
 import { UseCelo } from '@celo/react-celo';
 import Web3 from 'web3';
 
-export async function sendTransaction(
+export async function sendTestTransaction(
   performActions: UseCelo['performActions']
 ) {
   await performActions(async (k) => {

--- a/packages/example/utils/send-transaction.ts
+++ b/packages/example/utils/send-transaction.ts
@@ -1,0 +1,20 @@
+import { UseCelo } from '@celo/react-celo';
+import Web3 from 'web3';
+
+export async function sendTransaction(
+  performActions: UseCelo['performActions']
+) {
+  await performActions(async (k) => {
+    const celo = await k.contracts.getGoldToken();
+    await celo
+      .transfer(
+        // impact market contract
+        '0x73D20479390E1acdB243570b5B739655989412f5',
+        Web3.utils.toWei('0.00000001', 'ether')
+      )
+      .sendAndWaitForReceipt({
+        from: k.connection.defaultAccount,
+        gasPrice: k.connection.defaultGasPrice,
+      });
+  });
+}


### PR DESCRIPTION
This addresses #164 

### Overview

Following the draft PR https://github.com/celo-org/use-contractkit/pull/200, this PR adds a page to the Example app where the user can go through a set of steps to check how well a wallet interacts with the available actions from `react-celo`.

There are more tests to be added, but to avoid a huge PR, I'm opening this to merge these first ones.

I've simplified the UI a bit (compared to the Draft PR) to make it leaner and more consistent.

<img width="662" alt="image" src="https://user-images.githubusercontent.com/21973269/169858164-b94d0813-bf87-41fd-b21f-1d047e20ae98.png">


### Problems/UX issues I found that we could consider addressing

- Calling `destroy` for some reason doesn't update the `address` returned by `useCelo`. This means, if you click on it, you'll need to refresh the page to see the test reset.
- Even though the provider is set to Mainnet, if you change the network to Alfajores, then refresh the page, it will still be set to Alfajores - not sure if this is the expected behavior. I'd think it should at least prompt the user to change the network to Mainnet.
- Switching networks programmatically: initially I wanted to switch networks twice, from Mainnet to Alfajores and then back to Mainnet, but this caused a loop in Metamask because even though the promise ended, Metamask was still processing it.
- The message for the transaction never changes. Even when the user already approved the transaction, the message displayed is that the user needs to approve it (see the last part of the gif below). We could update the message when the user has already approved the transaction to say it's now just waiting on the tx to be confirmed in the blockchain.

### Demo

![Kapture 2022-05-23 at 17 50 33](https://user-images.githubusercontent.com/21973269/169858686-0474faee-5bd1-45ce-a20a-e60bfb9084f3.gif)
