### PR TITLE
fix: export useContractKit

### DIFF
--- a/packages/react-celo/src/index.ts
+++ b/packages/react-celo/src/index.ts
@@ -3,4 +3,4 @@ export * from './ethers';
 export * from './react-celo-provider';
 export { defaultScreens as Screens } from './screens';
 export * from './types';
-export { UseCelo, useCelo } from './use-celo';
+export { UseCelo, useCelo, useContractKit } from './use-celo';


### PR DESCRIPTION
### Overview

While going over the list of checks for `v4.0`, I noticed I couldn't use `useContractKit` .
I got the error:  `Module '"@celo/react-celo"' has no exported member 'useContractKit'.ts(2305)`

Adding it to the export in `react-celo/src/index.ts` fixed it.

