### PR TITLE
fix: destroy not re-rendering

### DIFF
--- a/packages/example/components/test-plan/disconnect-button.tsx
+++ b/packages/example/components/test-plan/disconnect-button.tsx
@@ -1,0 +1,12 @@
+import { useCelo } from '@celo/react-celo';
+import React from 'react';
+
+export default function DisconnectButton() {
+  const { destroy } = useCelo();
+
+  return (
+    <button className="inline underline text-purple-700" onClick={destroy}>
+      Disconnect wallet
+    </button>
+  );
+}

--- a/packages/example/pages/_app.tsx
+++ b/packages/example/pages/_app.tsx
@@ -6,8 +6,12 @@ import { AppProps } from 'next/app';
 import { Toaster } from 'react-hot-toast';
 
 function MyApp({ Component, pageProps, router }: AppProps): React.ReactElement {
-  if (router.route === '/wallet') {
-    return <Component {...pageProps} />;
+  if (router.route !== '/') {
+    return (
+      <div className="max-w-screen-sm mx-auto py-10 md:py-20 px-4">
+        <Component {...pageProps} />
+      </div>
+    );
   }
 
   return (

--- a/packages/example/pages/wallet-test-plan.tsx
+++ b/packages/example/pages/wallet-test-plan.tsx
@@ -1,13 +1,13 @@
-import { CeloProvider, Mainnet, useCelo } from '@celo/react-celo';
+import { CeloProvider, Mainnet } from '@celo/react-celo';
 import React from 'react';
 
 import { ConnectWalletCheck } from '../components/test-plan/connect-wallet';
+import DisconnectButton from '../components/test-plan/disconnect-button';
 import { SendTransaction } from '../components/test-plan/send-transaction';
 import { SwitchNetwork } from '../components/test-plan/switch-networks';
 import { UpdateFeeCurrency } from '../components/test-plan/update-fee-currency';
 
 export default function WalletTestPlan(): React.ReactElement {
-  const { destroy } = useCelo();
   return (
     <CeloProvider
       dapp={{
@@ -31,12 +31,7 @@ export default function WalletTestPlan(): React.ReactElement {
           test.
         </div>
         <div>
-          <button
-            className="inline underline text-purple-700"
-            onClick={destroy}
-          >
-            Disconnect wallet
-          </button>
+          <DisconnectButton />
         </div>
         <ConnectWalletCheck />
         <SwitchNetwork />


### PR DESCRIPTION
Disclaimer: there was nothing "wrong" with `destroy` per se, but the `wallet-test-plan` page was calling it outside of its provider.

The reason why this even worked at all is because the whole app is surrounded by a provider, i removed that to make sure we don't run into the error again.

fix #206 