### PR TITLE
Allow updateTheme to take a null value

### DIFF
--- a/packages/example/components/theme-button.tsx
+++ b/packages/example/components/theme-button.tsx
@@ -3,7 +3,7 @@ import { Theme } from '@celo/react-celo';
 interface Props {
   theme: Theme;
   currentTheme: Theme | null;
-  onClick: (theme: Theme) => void;
+  onClick: (theme: Theme | null) => void;
 }
 
 export function ThemeButton({ theme, currentTheme, onClick }: Props) {
@@ -17,7 +17,7 @@ export function ThemeButton({ theme, currentTheme, onClick }: Props) {
         padding: selected ? 3 : 4,
         borderColor: selected ? theme.primary : theme.muted,
       }}
-      onClick={() => onClick(theme)}
+      onClick={() => onClick(selected ? null : theme)}
     >
       <div className="flex flex-col gap-y-2 w-full">
         <div

--- a/packages/example/pages/index.tsx
+++ b/packages/example/pages/index.tsx
@@ -338,6 +338,7 @@ export default function Home(): React.ReactElement {
             </a>
           </div>
           <div className="text-slate-600 mb-4">
+            <p>Try out some of the pre-made themes below</p>
             <div className="grid grid-flow-col gap-4 my-4">
               {themes.map((theme, i) => (
                 <ThemeButton

--- a/packages/react-celo/src/use-celo-methods.ts
+++ b/packages/react-celo/src/use-celo-methods.ts
@@ -183,7 +183,8 @@ export function useCeloMethods(
   );
 
   const updateTheme = useCallback(
-    (theme: Theme) => {
+    (theme: Theme | null) => {
+      if (!theme) return dispatch('setTheme', null);
       Object.entries(theme).forEach(([key, value]: [string, string]) => {
         if (!(key in defaultTheme.light)) {
           console.warn(`Theme key ${key} is not valid.`);
@@ -259,5 +260,5 @@ export interface CeloMethods {
   ) => Promise<unknown[]>;
   updateFeeCurrency: (newFeeCurrency: CeloTokenContract) => Promise<void>;
   contractsCache?: undefined | unknown;
-  updateTheme: (theme: Theme) => void;
+  updateTheme: (theme: Theme | null) => void;
 }

--- a/packages/react-celo/src/use-celo.tsx
+++ b/packages/react-celo/src/use-celo.tsx
@@ -23,7 +23,7 @@ export interface UseCelo {
   networks: readonly Network[];
   updateNetwork: (network: Network) => Promise<void>;
   updateFeeCurrency: (newFeeCurrency: CeloTokenContract) => Promise<void>;
-  updateTheme: (theme: Theme) => void;
+  updateTheme: (theme: Theme | null) => void;
   supportsFeeCurrency: boolean;
   /**
    * Helper function for handling any interaction with a Celo wallet. Perform action will


### PR DESCRIPTION
Since the reducer state can take null I updated the `updateTheme` method to accept null. Also, I made it so you could turn off the themes in the example.