### PR TITLE
Fix #211 Cleanup Init Errors

### DIFF
--- a/packages/react-celo/src/modals/connect.tsx
+++ b/packages/react-celo/src/modals/connect.tsx
@@ -96,14 +96,21 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
   providersOptions = {},
 }: ConnectModalProps) => {
   const theme = useTheme();
-  const { connectionCallback } = useCeloInternal();
+
+  const { connectionCallback, resetInitError } = useCeloInternal();
   const [search, setSearch] = useState<string>('');
   const [adding, setAdding] = useState<Maybe<SupportedProviders>>(null);
 
+  const onClickProvider = (provider: SupportedProviders) => {
+    resetInitError();
+    setAdding(provider);
+  };
+
   const back = useCallback((): void => {
+    resetInitError();
     setSearch('');
     setAdding(null);
-  }, []);
+  }, [resetInitError, setSearch, setAdding]);
 
   const close = useCallback((): void => {
     back();
@@ -195,7 +202,7 @@ export const ConnectModal: React.FC<ConnectModalProps> = ({
           <Tray
             providers={providers}
             title={title}
-            onClickProvider={setAdding}
+            onClickProvider={onClickProvider}
             selectedProvider={adding}
             {...(searchable && {
               search: search,

--- a/packages/react-celo/src/use-celo-methods.ts
+++ b/packages/react-celo/src/use-celo-methods.ts
@@ -236,9 +236,14 @@ export function useCeloMethods(
 
   const contractsCache = useContractsCache(buildContractsCache, connector);
 
+  const resetInitError = useCallback(() => {
+    dispatch('setConnectorInitError', null);
+  }, [dispatch]);
+
   return {
     destroy,
     initConnector,
+    resetInitError,
     updateNetwork,
     connect,
     getConnectedKit,
@@ -250,6 +255,7 @@ export function useCeloMethods(
 }
 
 export interface CeloMethods {
+  resetInitError: () => void;
   destroy: () => Promise<void>;
   initConnector: (connector: Connector) => Promise<void>;
   updateNetwork: (network: Network) => Promise<void>;

--- a/packages/react-celo/src/use-celo.tsx
+++ b/packages/react-celo/src/use-celo.tsx
@@ -2,7 +2,7 @@ import { CeloTokenContract } from '@celo/contractkit/lib/base';
 import { MiniContractKit } from '@celo/contractkit/lib/mini-kit';
 
 import { WalletTypes } from './constants';
-import { useReactCeloContext } from './react-celo-provider';
+import { Dispatcher, useReactCeloContext } from './react-celo-provider';
 import { Connector, Dapp, Maybe, Network, Theme } from './types';
 
 export interface UseCelo {
@@ -112,6 +112,7 @@ interface UseCeloInternal extends UseCelo {
   initConnector: (connector: Connector) => Promise<void>;
   pendingActionCount: number;
   theme: Maybe<Theme>;
+  resetInitError: () => void;
 }
 
 /**
@@ -121,7 +122,7 @@ export const useCeloInternal = (): UseCeloInternal => {
   const [
     { pendingActionCount, connectionCallback, theme },
     _dispatch,
-    { initConnector },
+    { initConnector, resetInitError },
   ] = useReactCeloContext();
 
   return {
@@ -130,5 +131,6 @@ export const useCeloInternal = (): UseCeloInternal => {
     initConnector,
     pendingActionCount,
     theme,
+    resetInitError,
   };
 };


### PR DESCRIPTION
Cleans up initConnectorError when navigating between wallet screens in the connect modal. Otherwise an error for Ledger would show up on MetamaskScreen and vice verse 



fixes #211